### PR TITLE
docs: apply standardized README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ See [CONTRIBUTING.md](https://github.com/singi-labs/.github/blob/main/CONTRIBUTI
 
 ## Related Repositories
 
-| Repository                                                       | Description                              | License          |
-| ---------------------------------------------------------------- | ---------------------------------------- | ---------------- |
+| Repository                                                     | Description                              | License          |
+| -------------------------------------------------------------- | ---------------------------------------- | ---------------- |
 | [sifa-api](https://github.com/singi-labs/sifa-api)             | AppView backend (Fastify, AT Protocol)   | Source-available |
 | [sifa-web](https://github.com/singi-labs/sifa-web)             | Frontend (Next.js, React, TailwindCSS)   | Source-available |
 | [sifa-deploy](https://github.com/singi-labs/sifa-deploy)       | Docker Compose + Caddy deployment config | Source-available |


### PR DESCRIPTION
## Summary

- Add centered Sifa logo with dark/light theme support (uploaded to `.github` assets)
- Add status, license, validate workflow, Node.js, and TypeScript badges
- Restructure into consistent sections: Overview, Lexicon Schemas, Usage, Quick Start, Development, Related Repos, AT Protocol Resources, Community, License
- Match the template used across all Barazo repositories for org-wide consistency