### PR TITLE
ci: auto-add new issues to project board

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,14 @@
+name: Auto-add to project board
+
+on:
+  issues:
+    types: [opened, transferred]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/singi-labs/projects/2
+          github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Action that automatically adds new and transferred issues to the [Singi Labs Overview](https://github.com/orgs/singi-labs/projects/2) project board.

Requires `PROJECT_TOKEN` org secret (PAT with project read/write scope).