### PR TITLE
fix: resolve code scanning alerts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -6,7 +6,7 @@
  */
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const ROOT = new URL('..', import.meta.url).pathname;
 const LEXICONS_DIR = join(ROOT, 'lexicons');
@@ -34,8 +34,10 @@ const allFiles = [...ownFiles, ...externalFiles];
 
 console.log(`Found ${ownFiles.length} own + ${externalFiles.length} external lexicon files`);
 
-const cmd = `npx lex gen-server ${OUTPUT_DIR} ${allFiles.join(' ')} --yes`;
-execSync(cmd, { cwd: ROOT, stdio: 'inherit' });
+execFileSync('npx', ['lex', 'gen-server', OUTPUT_DIR, ...allFiles, '--yes'], {
+  cwd: ROOT,
+  stdio: 'inherit',
+});
 
 console.log('Running fixup script...');
-execSync('node scripts/fixup-generated.js', { cwd: ROOT, stdio: 'inherit' });
+execFileSync('node', ['scripts/fixup-generated.js'], { cwd: ROOT, stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to `validate.yml` (CodeQL alert #3)
- Replace `execSync` with `execFileSync` in `generate.js` to prevent shell command injection via filenames (CodeQL alert #4)
- Alert #5 (`auto-add-to-project.yml` missing permissions) is from the org-level `.github` repo and was already fixed there

## Test plan
- [ ] CI passes (validate, lint, typecheck, build)
- [ ] CodeQL alerts #3 and #4 close after merge