### PR TITLE
feat(lexicon): add isPrimary to externalAccount, remove website from self

### DIFF
--- a/lexicons/id/sifa/profile/externalAccount.json
+++ b/lexicons/id/sifa/profile/externalAccount.json
@@ -42,6 +42,10 @@
             "format": "uri",
             "description": "Optional RSS or Atom feed URL. Auto-discovered or manually provided. Used for content rendering in the ATmosphere Stream."
           },
+          "isPrimary": {
+            "type": "boolean",
+            "description": "Whether this is the user's primary external link, displayed prominently on the profile card."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -34,11 +34,6 @@
             "ref": "community.lexicon.location.address",
             "description": "Professional location (city, region, country). Uses community location lexicon."
           },
-          "website": {
-            "type": "string",
-            "format": "uri",
-            "description": "Professional website URL. Distinct from Bluesky profile website if needed."
-          },
           "openTo": {
             "type": "array",
             "maxLength": 10,


### PR DESCRIPTION
## Summary
- Add `isPrimary` boolean to `id.sifa.profile.externalAccount` lexicon — makes primary link portable across AppViews
- Remove `website` field from `id.sifa.profile.self` — redundant now that primary external account serves this purpose

## Changes
- `lexicons/id/sifa/profile/externalAccount.json`: Added `isPrimary` boolean property
- `lexicons/id/sifa/profile/self.json`: Removed `website` string property

## Test plan
- [ ] CI passes
- [ ] Lexicon JSON validates