### PR TITLE
feat(lexicon): add optional skills field to id.sifa.profile.position

### DIFF
--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -70,6 +70,15 @@
             "format": "datetime",
             "description": "End date of the position. Omit if this is a current position."
           },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "ref",
+              "ref": "com.atproto.repo.strongRef"
+            },
+            "description": "Skills used in this position. Each entry is a strongRef to an id.sifa.profile.skill record owned by the same DID.",
+            "maxLength": 50
+          },
           "labels": {
             "type": "union",
             "description": "Self-label values for this position record.",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -212,6 +212,35 @@ describe('All lexicons have a top-level description', () => {
   });
 });
 
+describe('Position skills field', () => {
+  const positionLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.position');
+  const properties = positionLexicon?.doc.defs.main.record?.properties;
+  const required = positionLexicon?.doc.defs.main.record?.required ?? [];
+
+  it('position lexicon exists', () => {
+    expect(positionLexicon).toBeDefined();
+  });
+
+  it('skills field exists and is an optional array', () => {
+    expect(properties?.skills).toBeDefined();
+    expect(properties?.skills?.type).toBe('array');
+    expect(required).not.toContain('skills');
+  });
+
+  it('skills items are strongRef references', () => {
+    expect(properties?.skills?.items?.type).toBe('ref');
+    expect(properties?.skills?.items?.ref).toBe('com.atproto.repo.strongRef');
+  });
+
+  it('skills array has maxLength 50', () => {
+    expect(properties?.skills?.maxLength).toBe(50);
+  });
+
+  it('position without skills field is still valid (backward compatible)', () => {
+    expect(required).toEqual(['company', 'title', 'startedAt', 'createdAt']);
+  });
+});
+
 describe('External lexicon references exist', () => {
   // Collect all external refs (not starting with # or id.sifa.)
   const externalRefs = new Set<string>();


### PR DESCRIPTION
## Summary

- Add optional `skills` array field to `id.sifa.profile.position` lexicon schema
- Each entry is a `com.atproto.repo.strongRef` pointing to an `id.sifa.profile.skill` record owned by the same DID
- Enables skill-position linking: "I used JavaScript as Senior Engineer at Stripe" instead of just "I know JavaScript"

## Changes

- `lexicons/id/sifa/profile/position.json` -- added `skills` field (array of strongRef, maxLength 50, optional)
- `tests/lexicons.test.ts` -- added 5 tests verifying skills field structure, strongRef type, maxLength, and backward compatibility

## Test plan

- [x] CI passes (lint, typecheck, build, tests)
- [x] All 133 tests pass (128 existing + 5 new)
- [x] Backward compatibility: existing position records without `skills` remain valid (not in `required`)
- [x] Generated TypeScript types include `skills?: ComAtprotoRepoStrongRef.Main[]`

Closes #11