### PR TITLE
ci: add Tangled mirror workflow

### DIFF
--- a/.github/workflows/tangled-mirror.yml
+++ b/.github/workflows/tangled-mirror.yml
@@ -1,0 +1,32 @@
+name: Mirror to Tangled
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.TANGLED_SSH_KEY }}" > ~/.ssh/tangled
+          chmod 600 ~/.ssh/tangled
+          cat >> ~/.ssh/config <<EOF
+          Host tangled.org
+            Hostname tangled.org
+            User git
+            IdentityFile ~/.ssh/tangled
+            StrictHostKeyChecking accept-new
+            AddressFamily inet
+          EOF
+
+      - name: Push to Tangled
+        run: |
+          git remote add tangled git@tangled.org:gui.do/${{ github.event.repository.name }}
+          git push tangled main --force


### PR DESCRIPTION
## Summary
- Adds GitHub Action to mirror `main` to tangled.org on every push
- Matches the existing setup used by Barazo repos
- Uses the org-level `TANGLED_SSH_KEY` secret

## Prerequisites
- Create `sifa-lexicons` repo on tangled.org under `gui.do` handle before merging