### PR TITLE
feat(defs): add platformOrcid to externalPlatform

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -114,6 +114,7 @@
         "id.sifa.defs#platformLinkedin",
         "id.sifa.defs#platformSubstack",
         "id.sifa.defs#platformWebsite",
+        "id.sifa.defs#platformOrcid",
         "id.sifa.defs#platformOther"
       ]
     },
@@ -132,6 +133,7 @@
     "platformLinkedin": { "type": "token", "description": "LinkedIn profile." },
     "platformSubstack": { "type": "token", "description": "Substack newsletter." },
     "platformWebsite": { "type": "token", "description": "Personal or professional website." },
+    "platformOrcid": { "type": "token", "description": "ORCID researcher identifier." },
     "platformOther": {
       "type": "token",
       "description": "Other platform not covered by specific tokens."

--- a/lexicons/id/sifa/profile/externalAccount.json
+++ b/lexicons/id/sifa/profile/externalAccount.json
@@ -23,6 +23,7 @@
               "id.sifa.defs#platformYoutube",
               "id.sifa.defs#platformLinkedin",
               "id.sifa.defs#platformWebsite",
+              "id.sifa.defs#platformOrcid",
               "id.sifa.defs#platformOther"
             ]
           },


### PR DESCRIPTION
## Summary
- Add `platformOrcid` token to `externalPlatform` enum in `id.sifa.defs`
- Add `id.sifa.defs#platformOrcid` to `externalAccount` knownValues

Part of the ORCID integration for verified scientific publications on Sifa profiles.

## Test plan
- [ ] CI checks pass
- [ ] Lexicon JSON validates correctly