### PR TITLE
feat: add multi-location lexicon support

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -137,6 +137,28 @@
     "platformOther": {
       "type": "token",
       "description": "Other platform not covered by specific tokens."
+    },
+
+    "locationType": {
+      "type": "string",
+      "description": "The role a location plays in a user's professional profile.",
+      "knownValues": [
+        "id.sifa.defs#locationPrimary",
+        "id.sifa.defs#locationBusiness",
+        "id.sifa.defs#locationTravel"
+      ]
+    },
+    "locationPrimary": {
+      "type": "token",
+      "description": "Primary residence or home location."
+    },
+    "locationBusiness": {
+      "type": "token",
+      "description": "Business or operational location."
+    },
+    "locationTravel": {
+      "type": "token",
+      "description": "Frequent travel or temporary location."
     }
   }
 }

--- a/lexicons/id/sifa/profile/location.json
+++ b/lexicons/id/sifa/profile/location.json
@@ -1,0 +1,47 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.profile.location",
+  "description": "A location associated with the user's professional profile. Supports multiple locations per user (e.g. residential, business, travel).",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A single location entry in the user's profile.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["address", "type", "createdAt"],
+        "properties": {
+          "address": {
+            "type": "ref",
+            "ref": "community.lexicon.location.address",
+            "description": "Location address using community location lexicon."
+          },
+          "type": {
+            "type": "string",
+            "description": "The role of this location.",
+            "knownValues": [
+              "id.sifa.defs#locationPrimary",
+              "id.sifa.defs#locationBusiness",
+              "id.sifa.defs#locationTravel"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "maxGraphemes": 60,
+            "maxLength": 600,
+            "description": "Optional user-defined label for this location."
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "description": "Whether this is the primary/display location."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was created."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New `id.sifa.profile.location` collection record type for multiple locations per profile
- Location type tokens added to `id.sifa.defs` (locationPrimary, locationBusiness, locationTravel)
- Uses existing `community.lexicon.location.address` reference for address data

## Test plan
- [ ] Lexicon JSON validates against ATproto lexicon schema
- [ ] New defs tokens are properly referenced from location lexicon

Fixes singi-labs/sifa-workspace#69