### PR TITLE
feat(lexicons): add connection lexicon and auth permission set

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ This package defines the `id.sifa.*` namespace -- the data contract between a us
 | `id.sifa.endorsement`              | Skill endorsements             |
 | `id.sifa.endorsement.confirmation` | Endorsement confirmations      |
 | `id.sifa.graph.follow`             | Professional follows           |
+| `id.sifa.graph.connection`         | Mutual professional connections |
+| `id.sifa.meeting`                  | Face-to-face meeting attestation |
 | `id.sifa.authProfileAccess`        | OAuth permission set           |
+| `id.sifa.authMeet`                 | Meeting attestation permission |
+| `id.sifa.authConnection`           | Connection management permission |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,27 +30,27 @@ This package defines the `id.sifa.*` namespace -- the data contract between a us
 
 ## Lexicon Schemas
 
-| NSID                               | Purpose                        |
-| ---------------------------------- | ------------------------------ |
-| `id.sifa.defs`                     | Shared tokens and types        |
-| `id.sifa.profile.self`             | Professional profile singleton |
-| `id.sifa.profile.position`         | Work experience                |
-| `id.sifa.profile.education`        | Education                      |
-| `id.sifa.profile.skill`            | Skills                         |
-| `id.sifa.profile.certification`    | Certifications and licenses    |
-| `id.sifa.profile.project`          | Projects                       |
-| `id.sifa.profile.volunteering`     | Volunteer experience           |
-| `id.sifa.profile.publication`      | Publications                   |
-| `id.sifa.profile.course`           | Courses                        |
-| `id.sifa.profile.honor`            | Honors and awards              |
-| `id.sifa.profile.language`         | Language proficiency           |
-| `id.sifa.endorsement`              | Skill endorsements             |
-| `id.sifa.endorsement.confirmation` | Endorsement confirmations      |
-| `id.sifa.graph.follow`             | Professional follows           |
-| `id.sifa.graph.connection`         | Mutual professional connections |
+| NSID                               | Purpose                          |
+| ---------------------------------- | -------------------------------- |
+| `id.sifa.defs`                     | Shared tokens and types          |
+| `id.sifa.profile.self`             | Professional profile singleton   |
+| `id.sifa.profile.position`         | Work experience                  |
+| `id.sifa.profile.education`        | Education                        |
+| `id.sifa.profile.skill`            | Skills                           |
+| `id.sifa.profile.certification`    | Certifications and licenses      |
+| `id.sifa.profile.project`          | Projects                         |
+| `id.sifa.profile.volunteering`     | Volunteer experience             |
+| `id.sifa.profile.publication`      | Publications                     |
+| `id.sifa.profile.course`           | Courses                          |
+| `id.sifa.profile.honor`            | Honors and awards                |
+| `id.sifa.profile.language`         | Language proficiency             |
+| `id.sifa.endorsement`              | Skill endorsements               |
+| `id.sifa.endorsement.confirmation` | Endorsement confirmations        |
+| `id.sifa.graph.follow`             | Professional follows             |
+| `id.sifa.graph.connection`         | Mutual professional connections  |
 | `id.sifa.meeting`                  | Face-to-face meeting attestation |
-| `id.sifa.authProfileAccess`        | OAuth permission set           |
-| `id.sifa.authMeet`                 | Meeting attestation permission |
+| `id.sifa.authProfileAccess`        | OAuth permission set             |
+| `id.sifa.authMeet`                 | Meeting attestation permission   |
 | `id.sifa.authConnection`           | Connection management permission |
 
 ---

--- a/lexicons/id/sifa/authConnection.json
+++ b/lexicons/id/sifa/authConnection.json
@@ -1,0 +1,19 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.authConnection",
+  "description": "OAuth permission set for creating and managing professional connections.",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "Professional connections",
+      "detail": "Create and manage professional connections with other users.",
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": ["id.sifa.graph.connection"]
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/id/sifa/authMeet.json
+++ b/lexicons/id/sifa/authMeet.json
@@ -1,6 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.authMeet",
+  "description": "OAuth permission set for recording verified face-to-face meetings.",
   "defs": {
     "main": {
       "type": "permission-set",

--- a/lexicons/id/sifa/authProfile.json
+++ b/lexicons/id/sifa/authProfile.json
@@ -1,6 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.authProfile",
+  "description": "OAuth permission set for editing professional profiles and following other users.",
   "defs": {
     "main": {
       "type": "permission-set",

--- a/lexicons/id/sifa/graph/connection.json
+++ b/lexicons/id/sifa/graph/connection.json
@@ -1,0 +1,60 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.graph.connection",
+  "description": "A mutual professional connection request. The requester creates this record; the subject accepts by creating their own record with the requester as subject. Both records must exist for the connection to be active. Either party can delete their record to sever the connection.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing a professional connection request or acceptance. Lives in the author's PDS.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the other party in the connection."
+          },
+          "origins": {
+            "type": "array",
+            "description": "How the connection originated. Each side can independently set their own origins.",
+            "maxLength": 5,
+            "items": {
+              "type": "ref",
+              "ref": "#origin"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this connection record was created."
+          }
+        }
+      }
+    },
+    "origin": {
+      "type": "object",
+      "description": "Describes how a connection originated — a shared project, event, or common interest.",
+      "required": ["type", "name"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "knownValues": ["project", "event", "interest"],
+          "description": "Category of the connection origin."
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "Optional AT URI referencing the origin record (e.g. a project or event record)."
+        },
+        "name": {
+          "type": "string",
+          "maxGraphemes": 100,
+          "maxLength": 1000,
+          "description": "Human-readable label for the origin."
+        }
+      }
+    }
+  }
+}

--- a/lexicons/id/sifa/meeting.json
+++ b/lexicons/id/sifa/meeting.json
@@ -1,6 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.meeting",
+  "description": "Attestation of a verified face-to-face meeting between two users, requiring mutual confirmation.",
   "defs": {
     "main": {
       "type": "record",

--- a/scripts/fixup-generated.js
+++ b/scripts/fixup-generated.js
@@ -14,6 +14,8 @@ const LEXICONS_DIR = new URL('../lexicons', import.meta.url).pathname;
 
 const EXCLUDED_LEXICONS = [
   { file: 'id/sifa/authProfileAccess.json', dictKey: 'IdSifaAuthProfileAccess' },
+  { file: 'id/sifa/authMeet.json', dictKey: 'IdSifaAuthMeet' },
+  { file: 'id/sifa/authConnection.json', dictKey: 'IdSifaAuthConnection' },
 ];
 
 async function getTypeFiles(dir) {

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -17,6 +17,7 @@ const EXCLUDED_FILES = [
   'authProfileAccess.json',
   'authProfile.json', // permission-set lexicon (not supported by lex-cli codegen)
   'authMeet.json', // permission-set lexicon (not supported by lex-cli codegen)
+  'authConnection.json', // permission-set lexicon (not supported by lex-cli codegen)
 ];
 
 function findJsonFiles(dir) {


### PR DESCRIPTION
## Summary

- Add `id.sifa.graph.connection` lexicon — mutual professional connection with `origins` array (project/event/interest, max 5 per side, independently editable)
- Add `id.sifa.authConnection` OAuth permission set for connection management
- Add top-level `description` to `authMeet`, `authProfile`, and `meeting` lexicons (fixes test failures)
- Update README with missing lexicon entries (`meeting`, `authMeet`, `graph.connection`, `authConnection`)
- Register new auth lexicons in codegen exclusion list and fixup injection

## Test plan
- [x] `npm run generate` succeeds (20 own + 9 external lexicons)
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (157/157 tests)
- [ ] CI checks pass

Fixes singi-labs/sifa-workspace#71