### PR TITLE
feat(lexicons): add collaborative project lexicons (Phase 1)

### DIFF
--- a/lexicons/id/sifa/authProject.json
+++ b/lexicons/id/sifa/authProject.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.authProject",
+  "description": "OAuth permission set for creating and managing collaborative projects and team memberships.",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "Collaborative projects",
+      "detail": "Create and manage collaborative projects, invite team members, and accept project invitations.",
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": [
+            "id.sifa.project.self",
+            "id.sifa.project.member",
+            "id.sifa.project.membership"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -159,6 +159,50 @@
     "locationTravel": {
       "type": "token",
       "description": "Frequent travel or temporary location."
+    },
+
+    "projectRole": {
+      "type": "string",
+      "description": "Role within a collaborative project.",
+      "knownValues": [
+        "id.sifa.defs#projectOwner",
+        "id.sifa.defs#projectCore",
+        "id.sifa.defs#projectContributor"
+      ]
+    },
+    "projectOwner": {
+      "type": "token",
+      "description": "Project owner with full management permissions. Multiple owners are supported."
+    },
+    "projectCore": {
+      "type": "token",
+      "description": "Core team member with elevated involvement."
+    },
+    "projectContributor": {
+      "type": "token",
+      "description": "Project contributor."
+    },
+
+    "projectStatus": {
+      "type": "string",
+      "description": "Current status of a collaborative project.",
+      "knownValues": [
+        "id.sifa.defs#projectActive",
+        "id.sifa.defs#projectCompleted",
+        "id.sifa.defs#projectArchived"
+      ]
+    },
+    "projectActive": {
+      "type": "token",
+      "description": "Project is actively maintained or in development."
+    },
+    "projectCompleted": {
+      "type": "token",
+      "description": "Project has been completed."
+    },
+    "projectArchived": {
+      "type": "token",
+      "description": "Project is archived and no longer active."
     }
   }
 }

--- a/lexicons/id/sifa/project/member.json
+++ b/lexicons/id/sifa/project/member.json
@@ -1,0 +1,44 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.project.member",
+  "description": "An invitation to join a project team, written by a project owner in their PDS. The invited user must create a corresponding id.sifa.project.membership record to confirm. Both records existing = confirmed team member.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing a team membership invitation. Written by a project owner to invite a user to the project team.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["project", "subject", "role", "createdAt"],
+        "properties": {
+          "project": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the id.sifa.project.self record. The AT-URI identifies the project, and the CID pins the version."
+          },
+          "subject": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the user being invited to the project team."
+          },
+          "role": {
+            "type": "ref",
+            "ref": "id.sifa.defs#projectRole",
+            "description": "Role assigned to the invited member."
+          },
+          "title": {
+            "type": "string",
+            "maxGraphemes": 128,
+            "maxLength": 1280,
+            "description": "Optional title or role description within the project (e.g. 'Lead Designer', 'Backend Engineer')."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this invitation was created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/id/sifa/project/membership.json
+++ b/lexicons/id/sifa/project/membership.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.project.membership",
+  "description": "Acceptance of a project team invitation. Written by the invited user in their own PDS. References the id.sifa.project.member invitation record. Both records existing = confirmed team member. Either party can delete their record to revoke membership.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing acceptance of a project team invitation. Lives in the invited user's PDS.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["project", "invitation", "createdAt"],
+        "properties": {
+          "project": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the id.sifa.project.self record being joined."
+          },
+          "invitation": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the id.sifa.project.member invitation record that this acceptance corresponds to."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this acceptance was created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/id/sifa/project/self.json
+++ b/lexicons/id/sifa/project/self.json
@@ -1,11 +1,11 @@
 {
   "lexicon": 1,
-  "id": "id.sifa.profile.project",
-  "description": "A project the user has worked on.",
+  "id": "id.sifa.project.self",
+  "description": "A collaborative project record. Lives in the project creator's PDS. TID-keyed so one user can create multiple projects. Supports multiple owners — the creator is the first owner, and any owner can promote core members.",
   "defs": {
     "main": {
       "type": "record",
-      "description": "Record representing a single project.",
+      "description": "Record representing a collaborative project. The rkey is a TID, not a literal 'self' — each user can create many projects.",
       "key": "tid",
       "record": {
         "type": "object",
@@ -22,22 +22,28 @@
             "type": "string",
             "maxGraphemes": 5000,
             "maxLength": 50000,
-            "description": "Description of the project, the user's role, and outcomes."
+            "description": "Description of the project, its goals, and scope."
           },
           "url": {
             "type": "string",
             "format": "uri",
-            "description": "URL of the project (website, repository, demo, etc.)."
+            "description": "Primary URL of the project (website, repository, etc.)."
           },
-          "projectRef": {
-            "type": "ref",
-            "ref": "com.atproto.repo.strongRef",
-            "description": "Reference to the first-class id.sifa.project.self record, if this personal project entry corresponds to a collaborative project."
+          "avatar": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg"],
+            "maxSize": 1000000,
+            "description": "Project avatar image. Max 1 MB, PNG or JPEG."
           },
-          "position": {
+          "organizationDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the organization this project belongs to, if any. Bridges to future company entities."
+          },
+          "status": {
             "type": "ref",
-            "ref": "com.atproto.repo.strongRef",
-            "description": "Reference to the associated id.sifa.profile.position record, if applicable."
+            "ref": "id.sifa.defs#projectStatus",
+            "description": "Current project status."
           },
           "startedAt": {
             "type": "string",

--- a/scripts/fixup-generated.js
+++ b/scripts/fixup-generated.js
@@ -16,6 +16,7 @@ const EXCLUDED_LEXICONS = [
   { file: 'id/sifa/authProfileAccess.json', dictKey: 'IdSifaAuthProfileAccess' },
   { file: 'id/sifa/authMeet.json', dictKey: 'IdSifaAuthMeet' },
   { file: 'id/sifa/authConnection.json', dictKey: 'IdSifaAuthConnection' },
+  { file: 'id/sifa/authProject.json', dictKey: 'IdSifaAuthProject' },
 ];
 
 async function getTypeFiles(dir) {

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -18,6 +18,7 @@ const EXCLUDED_FILES = [
   'authProfile.json', // permission-set lexicon (not supported by lex-cli codegen)
   'authMeet.json', // permission-set lexicon (not supported by lex-cli codegen)
   'authConnection.json', // permission-set lexicon (not supported by lex-cli codegen)
+  'authProject.json', // permission-set lexicon (not supported by lex-cli codegen)
 ];
 
 function findJsonFiles(dir) {


### PR DESCRIPTION
## Summary

- Adds `id.sifa.project` namespace with three new lexicons: `self` (TID-keyed project record supporting multiple owners), `member` (team invitation by owner), and `membership` (acceptance by invitee) — mutual confirmation model
- Adds `id.sifa.authProject` OAuth permission set for all three project collections
- Adds `projectRole` (owner/core/contributor) and `projectStatus` (active/completed/archived) token groups to `id.sifa.defs`
- Adds `projectRef` (strongRef) to `id.sifa.profile.project` to bridge personal project entries with first-class collaborative projects
- Updates `generate.js` and `fixup-generated.js` to handle the new auth lexicon

## Design decisions (per CEO review)

- Multiple owners from day one — creator is first owner, any owner can promote core members
- TID-keyed records (one user creates many projects) — not singleton
- Category field deferred (not included) — premature per CEO feedback
- Contributor privacy deferred — visible-by-default for MVP

## Test plan

- [x] `pnpm generate` succeeds (22 own + 9 external files, 4 auth lexicons injected)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (180 tests)
- [ ] CI checks pass

Fixes singi-labs/sifa-workspace#72