### PR TITLE
docs: update lexicon table with location, externalAccount, project, and auth lexicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,28 +32,28 @@ This package defines the `id.sifa.*` namespace -- the data contract between a us
 
 **Profile records**
 
-| NSID                              | Purpose                                       |
-| --------------------------------- | --------------------------------------------- |
-| `id.sifa.profile.self`            | Professional profile singleton                |
-| `id.sifa.profile.position`        | Work experience                               |
-| `id.sifa.profile.education`       | Education                                     |
-| `id.sifa.profile.skill`           | Skills                                        |
-| `id.sifa.profile.certification`   | Certifications and licenses                   |
-| `id.sifa.profile.project`         | Projects                                      |
-| `id.sifa.profile.volunteering`    | Volunteer experience                          |
-| `id.sifa.profile.publication`     | Publications                                  |
-| `id.sifa.profile.course`          | Courses                                       |
-| `id.sifa.profile.honor`           | Honors and awards                             |
-| `id.sifa.profile.language`        | Language proficiency                          |
-| `id.sifa.profile.location`        | Locations (residential, business, travel)     |
-| `id.sifa.profile.externalAccount` | Linked external accounts and websites         |
+| NSID                              | Purpose                                   |
+| --------------------------------- | ----------------------------------------- |
+| `id.sifa.profile.self`            | Professional profile singleton            |
+| `id.sifa.profile.position`        | Work experience                           |
+| `id.sifa.profile.education`       | Education                                 |
+| `id.sifa.profile.skill`           | Skills                                    |
+| `id.sifa.profile.certification`   | Certifications and licenses               |
+| `id.sifa.profile.project`         | Projects                                  |
+| `id.sifa.profile.volunteering`    | Volunteer experience                      |
+| `id.sifa.profile.publication`     | Publications                              |
+| `id.sifa.profile.course`          | Courses                                   |
+| `id.sifa.profile.honor`           | Honors and awards                         |
+| `id.sifa.profile.language`        | Language proficiency                      |
+| `id.sifa.profile.location`        | Locations (residential, business, travel) |
+| `id.sifa.profile.externalAccount` | Linked external accounts and websites     |
 
 **Social graph**
 
-| NSID                               | Purpose                         |
-| ---------------------------------- | ------------------------------- |
-| `id.sifa.graph.follow`             | Professional follows            |
-| `id.sifa.graph.connection`         | Mutual professional connections |
+| NSID                       | Purpose                         |
+| -------------------------- | ------------------------------- |
+| `id.sifa.graph.follow`     | Professional follows            |
+| `id.sifa.graph.connection` | Mutual professional connections |
 
 **Collaborative projects**
 
@@ -73,19 +73,19 @@ This package defines the `id.sifa.*` namespace -- the data contract between a us
 
 **OAuth permission sets**
 
-| NSID                        | Purpose                                      |
-| --------------------------- | -------------------------------------------- |
-| `id.sifa.authProfile`       | Profile editing and follows                  |
-| `id.sifa.authProfileAccess` | Profile access (legacy permission set)       |
-| `id.sifa.authMeet`          | Meeting attestation                          |
-| `id.sifa.authConnection`    | Connection management                        |
-| `id.sifa.authProject`       | Project creation and team management         |
+| NSID                        | Purpose                                |
+| --------------------------- | -------------------------------------- |
+| `id.sifa.authProfile`       | Profile editing and follows            |
+| `id.sifa.authProfileAccess` | Profile access (legacy permission set) |
+| `id.sifa.authMeet`          | Meeting attestation                    |
+| `id.sifa.authConnection`    | Connection management                  |
+| `id.sifa.authProject`       | Project creation and team management   |
 
 **Shared types**
 
-| NSID             | Purpose                 |
-| ---------------- | ----------------------- |
-| `id.sifa.defs`   | Shared tokens and types |
+| NSID           | Purpose                 |
+| -------------- | ----------------------- |
+| `id.sifa.defs` | Shared tokens and types |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,28 +30,62 @@ This package defines the `id.sifa.*` namespace -- the data contract between a us
 
 ## Lexicon Schemas
 
+**Profile records**
+
+| NSID                              | Purpose                                       |
+| --------------------------------- | --------------------------------------------- |
+| `id.sifa.profile.self`            | Professional profile singleton                |
+| `id.sifa.profile.position`        | Work experience                               |
+| `id.sifa.profile.education`       | Education                                     |
+| `id.sifa.profile.skill`           | Skills                                        |
+| `id.sifa.profile.certification`   | Certifications and licenses                   |
+| `id.sifa.profile.project`         | Projects                                      |
+| `id.sifa.profile.volunteering`    | Volunteer experience                          |
+| `id.sifa.profile.publication`     | Publications                                  |
+| `id.sifa.profile.course`          | Courses                                       |
+| `id.sifa.profile.honor`           | Honors and awards                             |
+| `id.sifa.profile.language`        | Language proficiency                          |
+| `id.sifa.profile.location`        | Locations (residential, business, travel)     |
+| `id.sifa.profile.externalAccount` | Linked external accounts and websites         |
+
+**Social graph**
+
+| NSID                               | Purpose                         |
+| ---------------------------------- | ------------------------------- |
+| `id.sifa.graph.follow`             | Professional follows            |
+| `id.sifa.graph.connection`         | Mutual professional connections |
+
+**Collaborative projects**
+
+| NSID                         | Purpose                                 |
+| ---------------------------- | --------------------------------------- |
+| `id.sifa.project.self`       | Collaborative project record            |
+| `id.sifa.project.member`     | Project team membership invitation      |
+| `id.sifa.project.membership` | Acceptance of a project team invitation |
+
+**Social interactions**
+
 | NSID                               | Purpose                          |
 | ---------------------------------- | -------------------------------- |
-| `id.sifa.defs`                     | Shared tokens and types          |
-| `id.sifa.profile.self`             | Professional profile singleton   |
-| `id.sifa.profile.position`         | Work experience                  |
-| `id.sifa.profile.education`        | Education                        |
-| `id.sifa.profile.skill`            | Skills                           |
-| `id.sifa.profile.certification`    | Certifications and licenses      |
-| `id.sifa.profile.project`          | Projects                         |
-| `id.sifa.profile.volunteering`     | Volunteer experience             |
-| `id.sifa.profile.publication`      | Publications                     |
-| `id.sifa.profile.course`           | Courses                          |
-| `id.sifa.profile.honor`            | Honors and awards                |
-| `id.sifa.profile.language`         | Language proficiency             |
 | `id.sifa.endorsement`              | Skill endorsements               |
 | `id.sifa.endorsement.confirmation` | Endorsement confirmations        |
-| `id.sifa.graph.follow`             | Professional follows             |
-| `id.sifa.graph.connection`         | Mutual professional connections  |
 | `id.sifa.meeting`                  | Face-to-face meeting attestation |
-| `id.sifa.authProfileAccess`        | OAuth permission set             |
-| `id.sifa.authMeet`                 | Meeting attestation permission   |
-| `id.sifa.authConnection`           | Connection management permission |
+
+**OAuth permission sets**
+
+| NSID                        | Purpose                                      |
+| --------------------------- | -------------------------------------------- |
+| `id.sifa.authProfile`       | Profile editing and follows                  |
+| `id.sifa.authProfileAccess` | Profile access (legacy permission set)       |
+| `id.sifa.authMeet`          | Meeting attestation                          |
+| `id.sifa.authConnection`    | Connection management                        |
+| `id.sifa.authProject`       | Project creation and team management         |
+
+**Shared types**
+
+| NSID             | Purpose                 |
+| ---------------- | ----------------------- |
+| `id.sifa.defs`   | Shared tokens and types |
 
 ---
 


### PR DESCRIPTION
## Summary

Brings the README lexicon table in sync with the actual repo contents. Seven lexicons were missing or undocumented:

- `id.sifa.profile.location` — added in #26, never reflected in README
- `id.sifa.profile.externalAccount` — existed from early on, never added to README
- `id.sifa.project.self`, `id.sifa.project.member`, `id.sifa.project.membership` — added in #28
- `id.sifa.authProfile` — added alongside other auth permission sets, missing from README
- `id.sifa.authProject` — added in #28, missing from README

Also reorganises the flat table into labelled groups (Profile records, Social graph, Collaborative projects, Social interactions, OAuth permission sets, Shared types) for easier navigation as the namespace grows.

No schema changes.