### PR TITLE
feat(defs): add id.sifa.defs#locationAddress type, use in profile/location

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -161,6 +161,32 @@
       "description": "Frequent travel or temporary location."
     },
 
+    "locationAddress": {
+      "type": "object",
+      "description": "A structured location address. countryCode is the single source of truth for the country; AppViews resolve it to a display name.",
+      "required": ["countryCode"],
+      "properties": {
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 alpha-2 country code (e.g. 'NL', 'US').",
+          "minLength": 2,
+          "maxLength": 2
+        },
+        "region": {
+          "type": "string",
+          "description": "Administrative region (state, province, etc.). Free text — AppViews display as-is.",
+          "maxGraphemes": 100,
+          "maxLength": 1000
+        },
+        "city": {
+          "type": "string",
+          "description": "City or locality name. Free text.",
+          "maxGraphemes": 100,
+          "maxLength": 1000
+        }
+      }
+    },
+
     "projectRole": {
       "type": "string",
       "description": "Role within a collaborative project.",

--- a/lexicons/id/sifa/profile/location.json
+++ b/lexicons/id/sifa/profile/location.json
@@ -13,8 +13,8 @@
         "properties": {
           "address": {
             "type": "ref",
-            "ref": "community.lexicon.location.address",
-            "description": "Location address using community location lexicon."
+            "ref": "id.sifa.defs#locationAddress",
+            "description": "Structured location address. countryCode is ISO 3166-1 alpha-2."
           },
           "type": {
             "type": "string",


### PR DESCRIPTION
## Summary

- Adds `id.sifa.defs#locationAddress` object type to `defs.json` with `countryCode` (required, ISO 3166-1 alpha-2), `region`, and `city`
- Updates `id.sifa.profile.location` to reference `id.sifa.defs#locationAddress` instead of `community.lexicon.location.address`
- `countryCode` is the single source of truth for the country; AppViews resolve it to a display name at index time

## Why

The `community.lexicon.location.address` type uses `locality` for city and expects the country code, but Sifa was storing a country name and using `city`. This honest custom type removes the mismatch and prevents `countryCode`/country name divergence across apps.

## Related

- sifa-api: singi-labs/sifa-api#feat/iso-location-address
- sifa-web: singi-labs/sifa-web#feat/iso-location-address