### PR TITLE
fix(lexicons): replace community location refs, add skillRef type

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -187,6 +187,19 @@
       }
     },
 
+    "skillRef": {
+      "type": "object",
+      "description": "A reference to an id.sifa.profile.skill record by AT-URI. No CID is required because skills are mutable records in the same user's repo.",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of the id.sifa.profile.skill record."
+        }
+      }
+    },
+
     "projectRole": {
       "type": "string",
       "description": "Role within a collaborative project.",

--- a/lexicons/id/sifa/profile/education.json
+++ b/lexicons/id/sifa/profile/education.json
@@ -55,7 +55,7 @@
           },
           "location": {
             "type": "ref",
-            "ref": "community.lexicon.location.address",
+            "ref": "id.sifa.defs#locationAddress",
             "description": "Institution location."
           },
           "startedAt": {

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -57,8 +57,8 @@
           },
           "location": {
             "type": "ref",
-            "ref": "community.lexicon.location.address",
-            "description": "Work location. Uses community location lexicon."
+            "ref": "id.sifa.defs#locationAddress",
+            "description": "Work location."
           },
           "startedAt": {
             "type": "string",
@@ -74,9 +74,9 @@
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "com.atproto.repo.strongRef"
+              "ref": "id.sifa.defs#skillRef"
             },
-            "description": "Skills used in this position. Each entry is a strongRef to an id.sifa.profile.skill record owned by the same DID.",
+            "description": "Skills used in this position. Each entry is a URI reference to an id.sifa.profile.skill record owned by the same DID.",
             "maxLength": 50
           },
           "isPrimary": {

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -31,8 +31,8 @@
           },
           "location": {
             "type": "ref",
-            "ref": "community.lexicon.location.address",
-            "description": "Professional location (city, region, country). Uses community location lexicon."
+            "ref": "id.sifa.defs#locationAddress",
+            "description": "Professional location (city, region, country)."
           },
           "openTo": {
             "type": "array",


### PR DESCRIPTION
## Summary

- Completes the work from #30: updates `education`, `position`, and `self` lexicons to use `id.sifa.defs#locationAddress` instead of `community.lexicon.location.address` (PR #30 only updated `profile/location`)
- Adds `id.sifa.defs#skillRef` (URI-only object) and uses it in `position.skills` instead of `com.atproto.repo.strongRef` — CIDs cannot be resolved at write time for newly created records, causing `LexValidationError` reported by community member

## Root causes fixed

1. `$.location.country` max 10 violation — community lexicon used country name ("Netherlands") instead of ISO code; our custom `locationAddress` type requires a 2-letter `countryCode` instead
2. `cid: ''` in position skills — `strongRef` requires a valid CID which is unavailable client-side; `skillRef` uses URI-only

## Test plan

- [ ] Verify lexicon validation passes for position records with `skills: [{uri: "at://..."}]`
- [ ] Verify location records with `countryCode: "NL"` validate against `locationAddress`
- [ ] Companion PRs: singi-labs/sifa-api#fix/lexicon-bugs, singi-labs/sifa-web#fix/lexicon-bugs