### PR TITLE
fix(lexicons): drop datetime format from career date fields

### DIFF
--- a/lexicons/id/sifa/profile/education.json
+++ b/lexicons/id/sifa/profile/education.json
@@ -60,13 +60,11 @@
           },
           "startedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Start date. For month-precision imports, use first day of month at midnight UTC."
+            "description": "Start date in YYYY-MM or YYYY-MM-DD format."
           },
           "endedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "End date (graduation or expected graduation). Omit if currently enrolled."
+            "description": "End date (graduation or expected graduation) in YYYY-MM or YYYY-MM-DD format. Omit if currently enrolled."
           },
           "labels": {
             "type": "union",

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -62,13 +62,11 @@
           },
           "startedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Start date of the position. For month-precision imports, use first day of month at midnight UTC."
+            "description": "Start date of the position in YYYY-MM or YYYY-MM-DD format."
           },
           "endedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "End date of the position. Omit if this is a current position."
+            "description": "End date of the position in YYYY-MM or YYYY-MM-DD format. Omit if this is a current position."
           },
           "skills": {
             "type": "array",

--- a/lexicons/id/sifa/profile/project.json
+++ b/lexicons/id/sifa/profile/project.json
@@ -41,13 +41,11 @@
           },
           "startedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Project start date."
+            "description": "Project start date in YYYY-MM or YYYY-MM-DD format."
           },
           "endedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Project end date. Omit if ongoing."
+            "description": "Project end date in YYYY-MM or YYYY-MM-DD format. Omit if ongoing."
           },
           "labels": {
             "type": "union",


### PR DESCRIPTION
## Problem

`startedAt` and `endedAt` in `position`, `education`, and `profile/project` lexicons had `"format": "datetime"`, which requires full ISO 8601 timestamps (e.g. `2020-01-01T00:00:00Z`). The UI sends month-precision strings like `2020-01`, which fail PDS validation with a format error.

## Fix

Remove the `format: "datetime"` constraint from all career date fields. The description now explicitly states `YYYY-MM or YYYY-MM-DD format`. `createdAt` fields are unchanged — they remain `format: "datetime"` as they are full server-generated timestamps.

Affected fields:
- `id.sifa.profile.position`: `startedAt`, `endedAt`
- `id.sifa.profile.education`: `startedAt`, `endedAt`
- `id.sifa.profile.project`: `startedAt`, `endedAt`

## Test plan

- [ ] Create/edit a position with month-precision dates (YYYY-MM) — no format validation error from PDS
- [ ] `createdAt` fields still validate as full datetime strings