### PR TITLE
feat: granular remote work types + timezone field

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -32,11 +32,33 @@
     "workplaceType": {
       "type": "string",
       "description": "The workplace arrangement.",
-      "knownValues": ["id.sifa.defs#onSite", "id.sifa.defs#remote", "id.sifa.defs#hybrid"]
+      "knownValues": [
+        "id.sifa.defs#onSite",
+        "id.sifa.defs#remote",
+        "id.sifa.defs#hybrid",
+        "id.sifa.defs#remoteLocal",
+        "id.sifa.defs#remoteRegion",
+        "id.sifa.defs#remoteGlobal"
+      ]
     },
     "onSite": { "type": "token", "description": "On-site/in-office work." },
-    "remote": { "type": "token", "description": "Fully remote work." },
+    "remote": {
+      "type": "token",
+      "description": "Fully remote work (unspecified scope). Treated as remoteGlobal by AppViews. Prefer the scoped variants for new records."
+    },
     "hybrid": { "type": "token", "description": "Hybrid on-site and remote work." },
+    "remoteLocal": {
+      "type": "token",
+      "description": "Remote work within the same country as the employer."
+    },
+    "remoteRegion": {
+      "type": "token",
+      "description": "Remote work within the same timezone region or continent."
+    },
+    "remoteGlobal": {
+      "type": "token",
+      "description": "Remote work from anywhere worldwide."
+    },
 
     "proficiency": {
       "type": "string",

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -67,11 +67,17 @@
             },
             "description": "Preferred workplace arrangements. Orthogonal to openTo. Empty array or omitted means no preference. Prefer the scoped remote variants (remoteLocal, remoteRegion, remoteGlobal) over the generic 'remote' token."
           },
-          "timezone": {
-            "type": "string",
-            "maxGraphemes": 50,
-            "maxLength": 500,
-            "description": "IANA timezone identifier (e.g., 'Europe/Amsterdam', 'America/New_York'). Used for work-hours visibility and search filtering."
+          "availableFromUtc": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 23,
+            "description": "Start of typical working hours in UTC (0-23). Used with availableToUtc for search filtering by work-hours overlap. Set via local-time UI, converted to UTC by the client."
+          },
+          "availableToUtc": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 23,
+            "description": "End of typical working hours in UTC (0-23). May wrap around midnight (e.g., from 22 to 06 for someone in Asia working US hours)."
           },
           "langs": {
             "type": "array",

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -53,12 +53,25 @@
           },
           "preferredWorkplace": {
             "type": "array",
-            "maxLength": 3,
+            "maxLength": 5,
             "items": {
               "type": "string",
-              "knownValues": ["id.sifa.defs#onSite", "id.sifa.defs#remote", "id.sifa.defs#hybrid"]
+              "knownValues": [
+                "id.sifa.defs#onSite",
+                "id.sifa.defs#remote",
+                "id.sifa.defs#hybrid",
+                "id.sifa.defs#remoteLocal",
+                "id.sifa.defs#remoteRegion",
+                "id.sifa.defs#remoteGlobal"
+              ]
             },
-            "description": "Preferred workplace arrangements. Orthogonal to openTo. Empty array or omitted means no preference."
+            "description": "Preferred workplace arrangements. Orthogonal to openTo. Empty array or omitted means no preference. Prefer the scoped remote variants (remoteLocal, remoteRegion, remoteGlobal) over the generic 'remote' token."
+          },
+          "timezone": {
+            "type": "string",
+            "maxGraphemes": 50,
+            "maxLength": 500,
+            "description": "IANA timezone identifier (e.g., 'Europe/Amsterdam', 'America/New_York'). Used for work-hours visibility and search filtering."
           },
           "langs": {
             "type": "array",


### PR DESCRIPTION
## Summary
- Add `remoteLocal`, `remoteRegion`, `remoteGlobal` tokens to `defs.json` workplace types
- Keep existing `remote` token for backwards compatibility (AppViews treat as `remoteGlobal`)
- Add `timezone` field (IANA identifier) to `profile.self` lexicon
- Bump `preferredWorkplace` maxLength from 3 to 5

## Context
Addresses NaBUru38's feedback: "there's no proper filter to distinguish semi-remote, country-based remote and worldwide remote."

Closes singi-labs/sifa-workspace#93 (lexicon portion)

## Test plan
- [ ] JSON validates (`python3 -c "import json; json.load(open('...'))"`)
- [ ] Existing records with `remote` value still valid (additive change)
- [ ] sifa-api and sifa-web companion PRs handle the new values