### PR TITLE
feat(profile): add displayName, avatar, pronouns to id.sifa.profile.self

### DIFF
--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.profile.self",
-  "description": "Professional profile summary. Singleton record providing professional identity beyond the base ATproto profile. Does not duplicate displayName, avatar, or bio from app.bsky.actor.profile.",
+  "description": "Professional profile summary. Singleton record providing professional identity beyond the base ATproto profile. Fields overlapping app.bsky.actor.profile (displayName, avatar, pronouns) act as optional professional-context overrides; absence means fall back to the bsky record.",
   "defs": {
     "main": {
       "type": "record",
@@ -11,6 +11,24 @@
         "type": "object",
         "required": ["createdAt"],
         "properties": {
+          "displayName": {
+            "type": "string",
+            "maxGraphemes": 64,
+            "maxLength": 640,
+            "description": "Professional-context display name. Overrides app.bsky.actor.profile.displayName when present."
+          },
+          "avatar": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg"],
+            "maxSize": 1000000,
+            "description": "Professional-context avatar image. Overrides app.bsky.actor.profile.avatar when present."
+          },
+          "pronouns": {
+            "type": "string",
+            "maxGraphemes": 20,
+            "maxLength": 200,
+            "description": "Free-form pronouns text. Professional-context override for app.bsky.actor.profile.pronouns."
+          },
           "headline": {
             "type": "string",
             "maxGraphemes": 120,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -10,6 +10,9 @@ interface LexiconProperty {
   format?: string;
   maxGraphemes?: number;
   maxLength?: number;
+  maxSize?: number;
+  accept?: string[];
+  description?: string;
   ref?: string;
   refs?: string[];
   items?: LexiconProperty;
@@ -237,6 +240,67 @@ describe('Position skills field', () => {
 
   it('position without skills field is still valid (backward compatible)', () => {
     expect(required).toEqual(['company', 'title', 'startedAt', 'createdAt']);
+  });
+});
+
+describe('id.sifa.profile.self presentation overrides', () => {
+  const selfLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.self');
+  const properties = selfLexicon?.doc.defs.main.record?.properties;
+  const required = selfLexicon?.doc.defs.main.record?.required ?? [];
+
+  it('lexicon exists', () => {
+    expect(selfLexicon).toBeDefined();
+  });
+
+  it('description no longer claims fields are non-duplicative of app.bsky.actor.profile', () => {
+    expect(selfLexicon?.doc.description).toBeDefined();
+    expect(selfLexicon!.doc.description).not.toMatch(/does not duplicate/i);
+  });
+
+  describe('displayName', () => {
+    it('exists as an optional string field', () => {
+      expect(properties?.displayName).toBeDefined();
+      expect(properties?.displayName?.type).toBe('string');
+      expect(required).not.toContain('displayName');
+    });
+
+    it('matches app.bsky.actor.profile.displayName constraints (64/640)', () => {
+      expect(properties?.displayName?.maxGraphemes).toBe(64);
+      expect(properties?.displayName?.maxLength).toBe(640);
+    });
+  });
+
+  describe('avatar', () => {
+    it('exists as an optional blob field', () => {
+      expect(properties?.avatar).toBeDefined();
+      expect(properties?.avatar?.type).toBe('blob');
+      expect(required).not.toContain('avatar');
+    });
+
+    it('matches app.bsky.actor.profile.avatar accept list (png, jpeg)', () => {
+      expect(properties?.avatar?.accept).toEqual(['image/png', 'image/jpeg']);
+    });
+
+    it('matches app.bsky.actor.profile.avatar size limit (1MB)', () => {
+      expect(properties?.avatar?.maxSize).toBe(1000000);
+    });
+  });
+
+  describe('pronouns', () => {
+    it('exists as an optional string field', () => {
+      expect(properties?.pronouns).toBeDefined();
+      expect(properties?.pronouns?.type).toBe('string');
+      expect(required).not.toContain('pronouns');
+    });
+
+    it('matches app.bsky.actor.profile.pronouns constraints (20/200)', () => {
+      expect(properties?.pronouns?.maxGraphemes).toBe(20);
+      expect(properties?.pronouns?.maxLength).toBe(200);
+    });
+
+    it('description identifies the field as a professional-context override', () => {
+      expect(properties?.pronouns?.description).toMatch(/professional/i);
+    });
   });
 });
 


### PR DESCRIPTION
Closes #38

## Summary

- Adds three optional presentation fields to \`id.sifa.profile.self\`:
  - \`displayName\` — string, maxGraphemes 64, maxLength 640
  - \`avatar\` — blob, accept [image/png, image/jpeg], maxSize 1MB
  - \`pronouns\` — string, maxGraphemes 20, maxLength 200
- Constraints match \`app.bsky.actor.profile\` exactly so consumers reusing bsky validation logic work without code changes.
- Updates the lexicon top-level description: removes the "does not duplicate" clause and explains the override semantics (absence means fall back to the bsky record).
- Bumps version to 0.2.0 (additive minor).

## Test plan

- [x] New tests in \`tests/lexicons.test.ts\` cover field existence, optionality, constraints, and the description rewrite (10 new assertions, all passing)
- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm build\` clean
- [x] \`pnpm generate\` produces updated TypeScript types in \`src/generated/\`
- [x] \`pnpm test\` — 182 passing; 7 pre-existing failures unrelated to this change (date-format work tracked separately on \`fix/date-fields-use-string\`)