### PR TITLE
feat!: adopt community.lexicon.location.address

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -445,32 +445,6 @@
       "description": "Frequent travel or temporary location."
     },
 
-    "locationAddress": {
-      "type": "object",
-      "description": "A structured location address. countryCode is the single source of truth for the country; AppViews resolve it to a display name.",
-      "required": ["countryCode"],
-      "properties": {
-        "countryCode": {
-          "type": "string",
-          "description": "ISO 3166-1 alpha-2 country code (e.g. 'NL', 'US').",
-          "minLength": 2,
-          "maxLength": 2
-        },
-        "region": {
-          "type": "string",
-          "description": "Administrative region (state, province, etc.). Free text — AppViews display as-is.",
-          "maxGraphemes": 100,
-          "maxLength": 1000
-        },
-        "city": {
-          "type": "string",
-          "description": "City or locality name. Free text.",
-          "maxGraphemes": 100,
-          "maxLength": 1000
-        }
-      }
-    },
-
     "skillRef": {
       "type": "object",
       "description": "A reference to an id.sifa.profile.skill record by AT-URI. No CID is required because skills are mutable records in the same user's repo.",

--- a/lexicons/id/sifa/profile/education.json
+++ b/lexicons/id/sifa/profile/education.json
@@ -55,7 +55,7 @@
           },
           "location": {
             "type": "ref",
-            "ref": "id.sifa.defs#locationAddress",
+            "ref": "community.lexicon.location.address",
             "description": "Institution location."
           },
           "startedAt": {

--- a/lexicons/id/sifa/profile/education.json
+++ b/lexicons/id/sifa/profile/education.json
@@ -56,7 +56,7 @@
           "location": {
             "type": "ref",
             "ref": "community.lexicon.location.address",
-            "description": "Institution location."
+            "description": "Institution location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
           },
           "startedAt": {
             "type": "string",

--- a/lexicons/id/sifa/profile/location.json
+++ b/lexicons/id/sifa/profile/location.json
@@ -14,7 +14,7 @@
           "address": {
             "type": "ref",
             "ref": "community.lexicon.location.address",
-            "description": "Structured location address. Sifa enforces ISO 3166-1 alpha-2 at the app layer."
+            "description": "Structured location address. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
           },
           "type": {
             "type": "string",

--- a/lexicons/id/sifa/profile/location.json
+++ b/lexicons/id/sifa/profile/location.json
@@ -13,8 +13,8 @@
         "properties": {
           "address": {
             "type": "ref",
-            "ref": "id.sifa.defs#locationAddress",
-            "description": "Structured location address. countryCode is ISO 3166-1 alpha-2."
+            "ref": "community.lexicon.location.address",
+            "description": "Structured location address. Sifa enforces ISO 3166-1 alpha-2 at the app layer."
           },
           "type": {
             "type": "string",

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -58,7 +58,7 @@
           "location": {
             "type": "ref",
             "ref": "community.lexicon.location.address",
-            "description": "Work location."
+            "description": "Work location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
           },
           "startedAt": {
             "type": "string",

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -57,7 +57,7 @@
           },
           "location": {
             "type": "ref",
-            "ref": "id.sifa.defs#locationAddress",
+            "ref": "community.lexicon.location.address",
             "description": "Work location."
           },
           "startedAt": {

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -52,8 +52,8 @@
           },
           "location": {
             "type": "ref",
-            "ref": "id.sifa.defs#locationAddress",
-            "description": "Professional location (city, region, country)."
+            "ref": "community.lexicon.location.address",
+            "description": "Professional location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
           },
           "openTo": {
             "type": "array",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -334,3 +334,17 @@ describe('External lexicon references exist', () => {
     },
   );
 });
+
+describe('community location adoption', () => {
+  const profilesWithLocation = ['self.json', 'position.json', 'education.json', 'location.json'];
+  for (const file of profilesWithLocation) {
+    it(`${file} references community.lexicon.location.address`, () => {
+      const lex = JSON.parse(
+        readFileSync(join(LEXICONS_DIR, 'profile', file), 'utf-8'),
+      );
+      const json = JSON.stringify(lex);
+      expect(json).toContain('community.lexicon.location.address');
+      expect(json).not.toContain('id.sifa.defs#locationAddress');
+    });
+  }
+});

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -339,10 +339,13 @@ describe('community location adoption', () => {
   const profilesWithLocation = ['self.json', 'position.json', 'education.json', 'location.json'];
   for (const file of profilesWithLocation) {
     it(`${file} references community.lexicon.location.address`, () => {
-      const lex = JSON.parse(readFileSync(join(LEXICONS_DIR, 'profile', file), 'utf-8'));
-      const json = JSON.stringify(lex);
-      expect(json).toContain('community.lexicon.location.address');
-      expect(json).not.toContain('id.sifa.defs#locationAddress');
+      const lex = JSON.parse(
+        readFileSync(join(LEXICONS_DIR, 'profile', file), 'utf-8'),
+      ) as LexiconDoc;
+      const properties = lex.defs.main.record?.properties ?? {};
+      const refs = collectRefs(properties);
+      expect(refs).toContain('community.lexicon.location.address');
+      expect(refs).not.toContain('id.sifa.defs#locationAddress');
     });
   }
 });

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -339,9 +339,7 @@ describe('community location adoption', () => {
   const profilesWithLocation = ['self.json', 'position.json', 'education.json', 'location.json'];
   for (const file of profilesWithLocation) {
     it(`${file} references community.lexicon.location.address`, () => {
-      const lex = JSON.parse(
-        readFileSync(join(LEXICONS_DIR, 'profile', file), 'utf-8'),
-      );
+      const lex = JSON.parse(readFileSync(join(LEXICONS_DIR, 'profile', file), 'utf-8'));
       const json = JSON.stringify(lex);
       expect(json).toContain('community.lexicon.location.address');
       expect(json).not.toContain('id.sifa.defs#locationAddress');


### PR DESCRIPTION
## Summary
- Switches `profile.self`, `profile.position`, `profile.education`, `profile.location` to ref `community.lexicon.location.address`
- Drops `id.sifa.defs#locationAddress`
- Bumps to 0.3.0 (breaking)

## Context: reversing PR #30/#31

PRs #30 and #31 (merged 2026-04-08/09) moved Sifa away from `community.lexicon.location.address` to a custom `id.sifa.defs#locationAddress` type. The stated reason was that the community type's permissive `country` field (2–10 chars) had let buggy client code submit country *names* like "Netherlands" instead of ISO codes, causing validation errors downstream.

This PR reverses that decision. The underlying concern (loose lexicon → loose data) is now addressed differently:

- **Strict alpha-2 at the app layer** — sifa-api's Zod input schema rejects non-alpha-2 country values before any handler runs (PR 2, Task 2.4).
- **Country-name normalization on PDS reads** — sifa-api's indexer normalizes alpha-3 codes, common aliases, and English country names to alpha-2 before indexing, so records other apps write to our collections survive (PR 2, Task 2.4b).

Net effect: same data hygiene as the custom type provided, plus cross-app interop with the community ecosystem (Smoke Signal already uses `community.lexicon.location.address` for event venues).

Tracking: singi-labs/sifa-workspace#157
Plan: `~/Documents/CoreNotes/Workspaces/Sifa/plans/2026-05-02-community-location-lexicon.md`

## Rationale
See `~/Documents/CoreNotes/Workspaces/Sifa/plans/2026-05-02-community-location-lexicon.md` and tracking issue #157.

## Test plan
- [x] Conformance test passes (asserts every profile lexicon refs community location)
- [x] Generated TS types include `country` + `locality`
- [ ] CI green