### PR TITLE
feat: add commissions to openToWorkStatus + refine contractRoles

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -365,6 +365,7 @@
         "id.sifa.defs#fullTimeRoles",
         "id.sifa.defs#partTimeRoles",
         "id.sifa.defs#contractRoles",
+        "id.sifa.defs#commissions",
         "id.sifa.defs#boardPositions",
         "id.sifa.defs#mentoringOthers",
         "id.sifa.defs#beingMentored",
@@ -379,7 +380,14 @@
       "type": "token",
       "description": "Open to part-time employment opportunities."
     },
-    "contractRoles": { "type": "token", "description": "Open to contract or freelance work." },
+    "contractRoles": {
+      "type": "token",
+      "description": "Open to B2B contract or project-based freelance work, consulting, contract development."
+    },
+    "commissions": {
+      "type": "token",
+      "description": "Open to commissioned creative work (illustration, design, voice work, music, etc.)."
+    },
     "boardPositions": { "type": "token", "description": "Open to advisory or board positions." },
     "mentoringOthers": { "type": "token", "description": "Open to mentoring others." },
     "beingMentored": { "type": "token", "description": "Open to being mentored." },

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -64,6 +64,7 @@
                 "id.sifa.defs#fullTimeRoles",
                 "id.sifa.defs#partTimeRoles",
                 "id.sifa.defs#contractRoles",
+                "id.sifa.defs#commissions",
                 "id.sifa.defs#boardPositions",
                 "id.sifa.defs#mentoringOthers",
                 "id.sifa.defs#beingMentored",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -349,3 +349,57 @@ describe('community location adoption', () => {
     });
   }
 });
+
+describe('openToWorkStatus commissions token', () => {
+  interface DefsDoc {
+    defs: {
+      openToWorkStatus: { knownValues: string[] };
+      commissions?: { type: string; description: string };
+      contractRoles?: { type: string; description: string };
+    };
+  }
+  interface SelfDoc {
+    defs: {
+      main: {
+        record: {
+          properties: {
+            openTo: { items: { knownValues: string[] } };
+          };
+        };
+      };
+    };
+  }
+  const defs = JSON.parse(readFileSync(join(LEXICONS_DIR, 'defs.json'), 'utf-8')) as DefsDoc;
+  const self = JSON.parse(
+    readFileSync(join(LEXICONS_DIR, 'profile', 'self.json'), 'utf-8'),
+  ) as SelfDoc;
+
+  it('defs.json declares a commissions token', () => {
+    expect(defs.defs.commissions).toBeDefined();
+    expect(defs.defs.commissions?.type).toBe('token');
+    expect(defs.defs.commissions?.description).toMatch(/commissioned creative work/i);
+  });
+
+  it('openToWorkStatus knownValues includes id.sifa.defs#commissions', () => {
+    expect(defs.defs.openToWorkStatus.knownValues).toContain('id.sifa.defs#commissions');
+  });
+
+  it('profile/self.json openTo knownValues includes id.sifa.defs#commissions', () => {
+    expect(self.defs.main.record.properties.openTo.items.knownValues).toContain(
+      'id.sifa.defs#commissions',
+    );
+  });
+
+  it('profile/self.json openTo knownValues stays in sync with defs.json openToWorkStatus', () => {
+    expect([...self.defs.main.record.properties.openTo.items.knownValues].sort()).toEqual(
+      [...defs.defs.openToWorkStatus.knownValues].sort(),
+    );
+  });
+
+  it('contractRoles description distinguishes B2B contract from individual commissions', () => {
+    expect(defs.defs.contractRoles?.description).toMatch(/B2B|consulting|project-based/i);
+    expect(defs.defs.contractRoles?.description).not.toMatch(
+      /^Open to contract or freelance work\.$/,
+    );
+  });
+});


### PR DESCRIPTION
Closes singi-labs/sifa-workspace#168.

## What changed

- `lexicons/id/sifa/defs.json`: added `id.sifa.defs#commissions` to `openToWorkStatus` knownValues + new token def. Narrowed `contractRoles` description from "Open to contract or freelance work." to "Open to B2B contract or project-based freelance work, consulting, contract development." so the line between the two tokens is legible.
- `lexicons/id/sifa/profile/self.json`: added `id.sifa.defs#commissions` to the inline openTo knownValues list (kept in sync by hand with defs.json).
- `tests/lexicons.test.ts`: 5 tests covering the new token + a permanent in-sync test that catches future drift between defs.json and self.json knownValues.
- `package.json`: 0.3.0 → 0.4.0 (minor, additive).

## Why

Public ecosystem ask from Patrick Singletary on Bluesky (2026-05-04, https://bsky.app/profile/psingletary.com/post/3ml2cqgnkb22p) proposing a Sifa → openmkt.app → rpg.actor → at.fund flywheel for pixel-art commissions. Four ATproto ecosystem actors coordinated on a concrete cross-app integration where Sifa is the identity layer.

Research confirmed (creative-freelancer persona, buyer persona, competitive intelligence, lexicon design, product strategy, red-team) that "commission" is a distinct primitive from "contract/freelance":

- Different deliverable shape (one-off creative piece vs ongoing engagement)
- Different price points (typically <\$2k vs SOW-scoped)
- Different IP terms (often retained/limited license vs assigned)
- Different verbs ("commission a piece" vs "hire a freelancer")
- ArtStation, Cara, VGen, Skeb, Fiverr all schema this distinction; LinkedIn and Polywork conflate it

**No major professional platform currently encodes "commissions" as a machine-readable, filterable token.** Sifa would be first.

## Safety

`knownValues` is non-exhaustive per the AT Protocol spec — validators accept unknown values. Existing 850+ user records and any writer that assumes a closed enum continue to work unchanged. No data migration. No PDS-validator update required.

## Reserved namespace

`id.sifa.commission` (singular) is reserved in this PR for a future per-listing record type carrying rate, queue status, deliverable type, contact method. **Not designed in this PR** — wait for concrete consumer demand from openmkt / rpg.actor integrations before specifying.

## Inclusion-rule precedent

Each `openToWorkStatus` token represents a distinct **engagement model** (different counterparty, duration, deliverable shape) — not a payment type or industry vertical. Future asks ("Tutoring", "Speaking gigs", "Voice acting") should pass that bar before getting added; "Bug bounties" or "Reviews-for-pay" wouldn't (those are payment mechanics, not engagement models).

## Out of scope (separate issues to file)

- Generic `externalRef: strongRef` field in `id.sifa.profile.project` so users can pin any AT-URI record (rpg.actor sprite, Skylight video, Whitewind essay) as a portfolio entry — powers Patrick's "sick portfolio on @sifa.id" vision generically.
- `rpg-actor` entry in sifa-api's `atproto-app-registry.ts` so the existing PDS-scanner-based activity stream brands rpg.actor records instead of showing them as "uncategorized."
- Future `id.sifa.commission` record type (per the reservation above).

## Test plan

- [x] `npx vitest run tests/lexicons.test.ts -t "openToWorkStatus commissions token"` — 5 new tests pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm run generate` — codegen succeeds, generated types include `id.sifa.defs#commissions` in the openTo union

## Note on existing test failures

7 vitest failures exist on `origin/main` (timestamps + skills strongRef) that are unrelated to this PR. They're not run in CI (`.github/workflows/validate.yml` only runs lint/typecheck/format/build) so main has been shipping with them. Out of scope here per surgical-changes rule.

## Follow-ups (will handle in this same flow)

- `sifa-api`: round-trip test for `commissions` token + lexicon validator dual-version note (small)
- `sifa-web`: add option to the openTo selector with label "Commissioned work" + i18n strings (small)
- After merge: cut a GitHub Release to trigger the publish workflow so external consumers (openmkt, rpg.actor) can validate against the new lexicon