### PR TITLE
feat(profile): expand employmentType knownValues + tighten descriptions

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -9,25 +9,66 @@
       "knownValues": [
         "id.sifa.defs#fullTime",
         "id.sifa.defs#partTime",
+        "id.sifa.defs#temporary",
+        "id.sifa.defs#seasonal",
         "id.sifa.defs#contract",
         "id.sifa.defs#freelance",
+        "id.sifa.defs#selfEmployed",
         "id.sifa.defs#internship",
         "id.sifa.defs#apprenticeship",
-        "id.sifa.defs#volunteer",
-        "id.sifa.defs#selfEmployed"
+        "id.sifa.defs#fellowship",
+        "id.sifa.defs#trainee",
+        "id.sifa.defs#volunteer"
       ]
     },
-    "fullTime": { "type": "token", "description": "Full-time employment." },
-    "partTime": { "type": "token", "description": "Part-time employment." },
-    "contract": { "type": "token", "description": "Contract/temporary employment." },
-    "freelance": { "type": "token", "description": "Freelance/independent work." },
-    "internship": { "type": "token", "description": "Internship position." },
-    "apprenticeship": { "type": "token", "description": "Apprenticeship position." },
+    "fullTime": {
+      "type": "token",
+      "description": "Full-time employee of the organization."
+    },
+    "partTime": {
+      "type": "token",
+      "description": "Part-time employee of the organization."
+    },
+    "temporary": {
+      "type": "token",
+      "description": "Fixed-end-date role as a direct employee of the organization."
+    },
+    "seasonal": {
+      "type": "token",
+      "description": "Recurring role tied to a season or peak period."
+    },
+    "contract": {
+      "type": "token",
+      "description": "Fixed-scope engagement as an independent contractor."
+    },
+    "freelance": {
+      "type": "token",
+      "description": "Solo service provider working with multiple clients on a project basis. No employees."
+    },
+    "selfEmployed": {
+      "type": "token",
+      "description": "Operating your own business or practice. May have employees."
+    },
+    "internship": {
+      "type": "token",
+      "description": "Structured early-career work experience, often tied to studies."
+    },
+    "apprenticeship": {
+      "type": "token",
+      "description": "Formal training-to-certification program combining paid work and education."
+    },
+    "fellowship": {
+      "type": "token",
+      "description": "Funded research, academic, or mission-driven position, typically selective."
+    },
+    "trainee": {
+      "type": "token",
+      "description": "Structured early-career rotation or graduate program."
+    },
     "volunteer": {
       "type": "token",
       "description": "Volunteer work (when used as employment type)."
     },
-    "selfEmployed": { "type": "token", "description": "Self-employed." },
 
     "workplaceType": {
       "type": "string",

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -42,12 +42,16 @@
             "knownValues": [
               "id.sifa.defs#fullTime",
               "id.sifa.defs#partTime",
+              "id.sifa.defs#temporary",
+              "id.sifa.defs#seasonal",
               "id.sifa.defs#contract",
               "id.sifa.defs#freelance",
+              "id.sifa.defs#selfEmployed",
               "id.sifa.defs#internship",
               "id.sifa.defs#apprenticeship",
-              "id.sifa.defs#volunteer",
-              "id.sifa.defs#selfEmployed"
+              "id.sifa.defs#fellowship",
+              "id.sifa.defs#trainee",
+              "id.sifa.defs#volunteer"
             ]
           },
           "workplaceType": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Closes singi-labs/sifa-workspace#176 (lexicon portion — full feature requires follow-up PRs in sifa-sdk, sifa-api, sifa-web).

## What changed

`id.sifa.defs#employmentType` knownValues expanded from 8 → 12. New values: `temporary`, `seasonal`, `fellowship`, `trainee`. Inline knownValues in `id.sifa.profile.position` synced to match.

All 12 token defs now have explicit per-value descriptions so the UI can render disambiguating tooltips. Previous descriptions like "Contract/temporary employment." conflated two distinct values; new descriptions make boundaries explicit.

## Why

Two users requested this feature independently on the same day (2026-05-14):
- https://bsky.app/profile/trueberryless.org/post/3mlt2zv5u6c2k
- https://bsky.app/profile/renderg.host/post/3mls7gxzjac2b

Stated user need: explain short tenures (e.g. a 3-month seasonal role or 1-month internship) that would otherwise look like job-hopping.

## Decision log

**Why these four, and not others researched:**

| Considered | Decision |
|---|---|
| `temporary` | **Add.** LinkedIn global + Google Jobs. Distinct from `contract`: fixed-end-date employee vs fixed-scope contractor. |
| `seasonal` | **Add.** LinkedIn (CA), Google Jobs. Globally meaningful. |
| `fellowship` | **Add.** Standard in academia, research, nonprofits, think tanks. Explicitly requested. |
| `trainee` | **Add.** LinkedIn (IN, BR). Distinct from apprenticeship — no certification path. |
| `coOp` | Reject. Ambiguous with cooperative business form (3M co-ops globally employing ~280M people). Academic meaning is NA + Germany only. Users can fall back to `internship`. |
| `externship` | Reject. US legal/medical niche, often "not deemed employment". |
| `casual` / `onCall` | Reject. UK/AU/CA-specific; overlaps `partTime` and `contract`. |
| `perDiem` | Reject. US healthcare-specific; overlaps `contract`. |
| `other` | Reject. ATproto `knownValues` is non-exhaustive by design — users can write freeform values. Adding `other` encourages bailing out of structured values. |

**Why keep freelance separate from selfEmployed:** ILO ICSE-18 formalizes the split as "Independent workers without employees" (freelance) vs "Employers" (selfEmployed with employees). Descriptions tightened to make this explicit. Most freelancers don't self-identify as "self-employed" even though legally they are.

**Description tightening:**
- `freelance`: "Solo service provider working with multiple clients on a project basis. No employees."
- `selfEmployed`: "Operating your own business or practice. May have employees."
- `contract`: "Fixed-scope engagement as an independent contractor." (was "Contract/temporary employment.")
- `temporary`: "Fixed-end-date role as a direct employee of the organization." (new — fills the gap left by separating temp from contract)

## Ordering

`knownValues` reordered semantically rather than alphabetically:
1. Employee schedule: fullTime, partTime, temporary, seasonal
2. Independent: contract, freelance, selfEmployed
3. Training-track: internship, apprenticeship, fellowship, trainee
4. Unpaid: volunteer

This also drives dropdown UX in the consuming frontend.

## Versioning

Minor bump 0.4.0 → 0.5.0. Additive change only (new knownValues are not breaking; existing tokens unchanged). Per ATproto convention, `knownValues` is non-exhaustive — adding values cannot break any existing record.

## Verification

- `npm run validate` — passes; generated types regenerated cleanly with new `'id.sifa.defs#temporary'`, `'seasonal'`, `'fellowship'`, `'trainee'` in the `Defs.KnownValue` union.
- `npm test` — 192 pass, 7 fail. **The 7 failures are pre-existing on `origin/main`** (stale tests checking for `format: "datetime"` on date fields that intentionally allow YYYY-MM, and `com.atproto.repo.strongRef` on skill items that intentionally use `id.sifa.defs#skillRef`). Verified by running tests on `origin/main` before my change.

## Out of scope

- Adding `employmentType` to the UI in sifa-web — separate PR.
- Adding the type to `sifa-sdk`'s `ProfilePosition` interface — separate PR.
- Normalizing the 35 existing prod records that use plain-string values (`full-time`, `part-time`) to canonical URIs — separate PR in sifa-api.