### PR TITLE
feat(profile): add independentWork employment type

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -14,6 +14,7 @@
         "id.sifa.defs#contract",
         "id.sifa.defs#freelance",
         "id.sifa.defs#selfEmployed",
+        "id.sifa.defs#independentWork",
         "id.sifa.defs#internship",
         "id.sifa.defs#apprenticeship",
         "id.sifa.defs#fellowship",
@@ -48,6 +49,10 @@
     "selfEmployed": {
       "type": "token",
       "description": "Operating your own business or practice. May have employees."
+    },
+    "independentWork": {
+      "type": "token",
+      "description": "Self-initiated, sustained work I lead — community building, content creation, ecosystem contribution, or similar. May involve a registered entity but does not pay me personally. Often run alongside other employment."
     },
     "internship": {
       "type": "token",

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -47,6 +47,7 @@
               "id.sifa.defs#contract",
               "id.sifa.defs#freelance",
               "id.sifa.defs#selfEmployed",
+              "id.sifa.defs#independentWork",
               "id.sifa.defs#internship",
               "id.sifa.defs#apprenticeship",
               "id.sifa.defs#fellowship",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Refs singi-labs/sifa-workspace#176. Follow-up to #42.

## What

One new value on `id.sifa.defs#employmentType`: **`independentWork`**.

Sync in both `defs.json` (token def + knownValues) and `profile/position.json` (inline knownValues). Minor bump 0.5.0 → 0.6.0.

## Why

The 12 values from #42 don't cleanly cover a real pattern: **sustained, self-initiated work the user leads, where no employer exists and no personal income is drawn — even when a registered entity handles revenue.** Examples surfaced by @gui.do's profile:

- CRO.CAFE podcast (4 years, 200+ episodes, 4 languages, sponsorships)
- Dutchento community (13 years, 11 editions of Meet Magento NL, 600+ attendees)
- Persuasionistas (community of practice)
- DutchJoomla! (3 years, ~15 volunteer translators coordinated)

None map cleanly:

| Existing value | Why it doesn't fit |
|---|---|
| `selfEmployed` | Implies the entity pays you. These don't. |
| `freelance` | Implies client work. No clients. |
| `volunteer` | Implies contributing to someone else's existing entity. These were founded and led by the user. (Note: once an entity outgrows the founder and has independent governance — like Magento Association — `volunteer` becomes the right value. The bright line is leadership/control, not origination.) |
| `partTime` / `temporary` / `seasonal` | All require an employer relationship. |

## MECE preservation

The 13-value set splits cleanly on two axes:

| Axis | Values |
|---|---|
| Employee schedule | fullTime, partTime, temporary, seasonal |
| Independent (no employer) | contract, freelance, selfEmployed, **independentWork** |
| Training-track | internship, apprenticeship, fellowship, trainee |
| Volunteer | volunteer |

Bright-line test between `selfEmployed` and `independentWork`: **"Does this thing pay me personally?"** Yes → selfEmployed. No → independentWork. Holds even if a registered entity exists — what matters is whether income flows to the individual.

Bright-line test between `volunteer` and `independentWork`: **"Whose entity is this?"** Someone else's → volunteer. Mine, I lead it → independentWork.

## Placement

Inserted in the "Independent" group of the knownValues array, after `selfEmployed`:

```
fullTime, partTime, temporary, seasonal,
contract, freelance, selfEmployed, independentWork,   ← new
internship, apprenticeship, fellowship, trainee,
volunteer
```

This grouping drives the consuming frontend's dropdown layout (web PR forthcoming with `<optgroup>` grouping).

## Token description

```
independentWork: "Self-initiated, sustained work I lead — community
building, content creation, ecosystem contribution, or similar. May
involve a registered entity but does not pay me personally. Often run
alongside other employment."
```

## Versioning

Minor bump 0.5.0 → 0.6.0. Additive, non-breaking (new knownValue cannot break existing records by ATproto convention; knownValues is non-exhaustive).

## Verification

- `npm run validate` — passes; codegen produces `'id.sifa.defs#independentWork'` in `Defs.KnownValue` union and `INDEPENDENTWORK` constant.
- `npm test` — 192 / 199 pass. **The 7 failures are pre-existing on `origin/main`** (same set as on #42: stale tests checking `format: "datetime"` and `com.atproto.repo.strongRef`).

## Follow-ups

- sifa-web — new PR adding the option + `<optgroup>` grouping for the existing 12 values + native `title` tooltips so users can see descriptions while choosing.
- sifa-api — no change needed (string field passes through; no prod records use a plain-string form of this value to normalize).
- sifa-sdk — no change needed (`employmentType` is typed as `string`).