### PR TITLE
docs: replace GitHub Discussions link with Bluesky in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ See [CONTRIBUTING.md](https://github.com/singi-labs/.github/blob/main/CONTRIBUTI
 ## Community
 
 - **Website:** [sifa.id](https://sifa.id)
-- **Discussions:** [GitHub Discussions](https://github.com/orgs/singi-labs/discussions)
+- **Bluesky:** [@sifa.id](https://bsky.app/profile/sifa.id)
 - **Issues:** [Report bugs](https://github.com/singi-labs/sifa-lexicons/issues)
 
 ---


### PR DESCRIPTION
## Summary

- We never enabled GitHub Discussions on the `singi-labs` org, so the link 404s for anyone who clicks it.
- Replaces the `Discussions` line in the Community section with a Bluesky link to the product handle (which is where people already reach out).
- Part of an org-wide sweep across all 14 repos (see also: companion PRs).

## Test plan

- [x] Visual review of rendered README
- [x] Verify Bluesky link resolves