### PR TITLE
feat(profile): add optional discoverable flag

### DIFF
--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -115,6 +115,10 @@
             "description": "Self-label values for the professional profile.",
             "refs": ["com.atproto.label.defs#selfLabels"]
           },
+          "discoverable": {
+            "type": "boolean",
+            "description": "Whether the rendered profile page may be indexed by search engines and AI tools. Default true when absent. When false, the rendering app emits noindex directives and excludes the page from any sitemap or push-indexing protocol. Does not affect the public visibility of the underlying ATproto records, which remain readable by any client."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Adds optional `discoverable: boolean` to `id.sifa.profile.self`. Bumps package version 0.6.0 → 0.6.1 (patch — additive optional field, per [version bumps convention](https://github.com/singi-labs/sifa-workspace)).

When absent, rendering apps treat the value as `true` — current behavior unchanged for all existing records.

When `false`, rendering apps are expected to:
- emit stronger `noindex` directives on the profile page (`robots`: noindex,nofollow,noarchive + `googlebot`: noindex)
- exclude the page from any sitemap
- skip the page in any push-indexing protocol (IndexNow etc.)

The flag governs only how the rendering app presents the page to search engines and AI crawlers. Underlying ATproto records remain public and readable by other clients.

## Why

User-facing discoverability opt-out. A complete, active profile may still want to opt out of search/AI indexing if the user prefers another site (LinkedIn, portfolio) to be the primary result for their name. See singi-labs/sifa-web#948 for the full implementation plan across repos.

Single bucket (search engines + AI together) is a deliberate brand decision, not a technical limitation.

## Test plan

- [x] Validation script regenerates types without error (`npm run generate`)
- [x] Pre-existing `vitest run` failures (date format, skill refs) confirmed unrelated — no new failures
- [ ] After merge + release: `@singi-labs/sifa-lexicons@0.6.1` exposes the field

Refs singi-labs/sifa-web#948