### PR TITLE
feat(publish): lexicon publisher scripts + OAuth client metadata (Phase 1)

### DIFF
--- a/.github/workflows/publish-lexicons.yml
+++ b/.github/workflows/publish-lexicons.yml
@@ -1,0 +1,45 @@
+name: Publish lexicons
+
+# Republishes every lexicons/**/*.json as a com.atproto.lexicon.schema record
+# on the authority DID's PDS whenever lexicon JSON changes land on main.
+# Idempotent: scripts/publish-lexicons.ts skips unchanged records.
+#
+# Secrets required (set on singi-labs/sifa-lexicons):
+#   LEXICON_PUBLISHER_DID
+#   LEXICON_PUBLISHER_REFRESH_TOKEN
+#   LEXICON_PUBLISHER_DPOP_KEY_JWK
+#   LEXICON_PUBLISHER_TOKEN_SET
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lexicons/**/*.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-lexicons
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: npm
+
+      - run: npm ci
+
+      - name: Publish lexicons to authority PDS
+        env:
+          LEXICON_PUBLISHER_DID: ${{ secrets.LEXICON_PUBLISHER_DID }}
+          LEXICON_PUBLISHER_REFRESH_TOKEN: ${{ secrets.LEXICON_PUBLISHER_REFRESH_TOKEN }}
+          LEXICON_PUBLISHER_DPOP_KEY_JWK: ${{ secrets.LEXICON_PUBLISHER_DPOP_KEY_JWK }}
+          LEXICON_PUBLISHER_TOKEN_SET: ${{ secrets.LEXICON_PUBLISHER_TOKEN_SET }}
+        run: npm run publish:lexicons

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 dist/
+dist-scripts/
 src/generated/
+.oauth-bootstrap-result.json
+.env
+.env.local

--- a/client-metadata.json
+++ b/client-metadata.json
@@ -1,0 +1,29 @@
+{
+  "client_id": "https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json",
+  "client_name": "Sifa Lexicon Publisher",
+  "client_uri": "https://sifa.id",
+  "logo_uri": "https://sifa.id/icon.png",
+  "tos_uri": "https://sifa.id/terms",
+  "policy_uri": "https://sifa.id/privacy",
+  "redirect_uris": ["http://127.0.0.1:8765/callback"],
+  "scope": "atproto transition:generic",
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "private_key_jwt",
+  "token_endpoint_auth_signing_alg": "ES256",
+  "dpop_bound_access_tokens": true,
+  "application_type": "native",
+  "jwks": {
+    "keys": [
+      {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "REPLACE_WITH_PUBLIC_X",
+        "y": "REPLACE_WITH_PUBLIC_Y",
+        "kid": "lexicon-publisher-1",
+        "use": "sig",
+        "alg": "ES256"
+      }
+    ]
+  }
+}

--- a/client-metadata.json
+++ b/client-metadata.json
@@ -9,21 +9,7 @@
   "scope": "atproto transition:generic",
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
-  "token_endpoint_auth_method": "private_key_jwt",
-  "token_endpoint_auth_signing_alg": "ES256",
+  "token_endpoint_auth_method": "none",
   "dpop_bound_access_tokens": true,
-  "application_type": "native",
-  "jwks": {
-    "keys": [
-      {
-        "kty": "EC",
-        "crv": "P-256",
-        "x": "REPLACE_WITH_PUBLIC_X",
-        "y": "REPLACE_WITH_PUBLIC_Y",
-        "kid": "lexicon-publisher-1",
-        "use": "sig",
-        "alg": "ES256"
-      }
-    ]
-  }
+  "application_type": "native"
 }

--- a/docs/lexicon-publishing.md
+++ b/docs/lexicon-publishing.md
@@ -7,13 +7,13 @@ the `id.sifa.*` namespace at runtime.
 
 ## Identity
 
-| | |
-|--|--|
-| Authority DID | `did:plc:2f2ahswozqy4v5lvu676375y` |
-| PDS | `https://eurosky.social` |
-| DNS proof | `_lexicon.sifa.id TXT did=did:plc:2f2ahswozqy4v5lvu676375y` (already configured) |
-| Client metadata | `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json` (served by sifa-api) |
-| Auth | OAuth 2.0 public native client (`token_endpoint_auth_method=none`), DPoP. atproto OAuth requires native clients to use `none` auth — confidential `private_key_jwt` is only available for `application_type=web` with HTTPS redirects. No app passwords. |
+|                 |                                                                                                                                                                                                                                                          |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Authority DID   | `did:plc:2f2ahswozqy4v5lvu676375y`                                                                                                                                                                                                                       |
+| PDS             | `https://eurosky.social`                                                                                                                                                                                                                                 |
+| DNS proof       | `_lexicon.sifa.id TXT did=did:plc:2f2ahswozqy4v5lvu676375y` (already configured)                                                                                                                                                                         |
+| Client metadata | `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json` (served by sifa-api)                                                                                                                                                           |
+| Auth            | OAuth 2.0 public native client (`token_endpoint_auth_method=none`), DPoP. atproto OAuth requires native clients to use `none` auth — confidential `private_key_jwt` is only available for `application_type=web` with HTTPS redirects. No app passwords. |
 
 ## One-time bootstrap (manual, done once per service identity)
 
@@ -46,12 +46,12 @@ The script:
 
 Set these as GitHub Actions secrets on `singi-labs/sifa-lexicons`:
 
-| Secret | Source field |
-|--------|--------------|
-| `LEXICON_PUBLISHER_DID` | `did` |
-| `LEXICON_PUBLISHER_REFRESH_TOKEN` | `refreshToken` |
-| `LEXICON_PUBLISHER_DPOP_KEY_JWK` | `dpopJwk` (full JSON object) |
-| `LEXICON_PUBLISHER_TOKEN_SET` | `tokenSet` (full JSON object) |
+| Secret                            | Source field                  |
+| --------------------------------- | ----------------------------- |
+| `LEXICON_PUBLISHER_DID`           | `did`                         |
+| `LEXICON_PUBLISHER_REFRESH_TOKEN` | `refreshToken`                |
+| `LEXICON_PUBLISHER_DPOP_KEY_JWK`  | `dpopJwk` (full JSON object)  |
+| `LEXICON_PUBLISHER_TOKEN_SET`     | `tokenSet` (full JSON object) |
 
 Then delete `.oauth-bootstrap-result.json`.
 

--- a/docs/lexicon-publishing.md
+++ b/docs/lexicon-publishing.md
@@ -12,20 +12,16 @@ the `id.sifa.*` namespace at runtime.
 | Authority DID | `did:plc:2f2ahswozqy4v5lvu676375y` |
 | PDS | `https://eurosky.social` |
 | DNS proof | `_lexicon.sifa.id TXT did=did:plc:2f2ahswozqy4v5lvu676375y` (already configured) |
-| Client metadata | `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json` (hosted by sifa-web) |
-| Auth | OAuth 2.0 confidential client, `private_key_jwt`, ES256, DPoP. No app passwords. |
+| Client metadata | `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json` (served by sifa-api) |
+| Auth | OAuth 2.0 public native client (`token_endpoint_auth_method=none`), DPoP. atproto OAuth requires native clients to use `none` auth — confidential `private_key_jwt` is only available for `application_type=web` with HTTPS redirects. No app passwords. |
 
 ## One-time bootstrap (manual, done once per service identity)
 
 Prerequisites:
 
-1. The OAuth client metadata file must already be live at
-   `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json`.
-   The hosted copy is shipped from the sifa-web repo (see
-   `sifa-web/public/.well-known/sifa-lexicon-publisher/client-metadata.json`).
-   On first run the public JWK inside it is a placeholder — you'll replace it
-   with the real public JWK generated below.
-
+1. The OAuth client metadata is served by sifa-api at
+   `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json`
+   (see `sifa-api/src/routes/well-known.ts`).
 2. You can sign into eurosky.social as the authority DID (handle + password).
 
 Steps:
@@ -38,16 +34,13 @@ pnpm publish:bootstrap did:plc:2f2ahswozqy4v5lvu676375y
 
 The script:
 
-1. Generates an ES256 keypair (kid `lexicon-publisher-1`).
-2. Prints the public JWK. Update the sifa-web `client-metadata.json` so its
-   `jwks.keys[0]` equals this public JWK, deploy, then press Enter.
-3. Opens your browser at the eurosky.social authorize endpoint.
-4. Captures the callback at `http://127.0.0.1:8765/callback`.
-5. Exchanges the code for an access + refresh token bound to the DPoP key.
-6. Writes `.oauth-bootstrap-result.json` (gitignored, mode 0600) containing:
+1. Opens your browser at the eurosky.social authorize endpoint.
+2. Captures the callback at `http://127.0.0.1:8765/callback`.
+3. Exchanges the code for an access + refresh token bound to the DPoP key
+   (generated internally by `@atproto/oauth-client-node`).
+4. Writes `.oauth-bootstrap-result.json` (gitignored, mode 0600) containing:
    - `did`
    - `refreshToken`
-   - `signingKeyJwk` (private ES256 JWK)
    - `dpopJwk` (private DPoP JWK)
    - `tokenSet` (full token set including expiry)
 
@@ -57,7 +50,6 @@ Set these as GitHub Actions secrets on `singi-labs/sifa-lexicons`:
 |--------|--------------|
 | `LEXICON_PUBLISHER_DID` | `did` |
 | `LEXICON_PUBLISHER_REFRESH_TOKEN` | `refreshToken` |
-| `LEXICON_PUBLISHER_SIGNING_KEY_JWK` | `signingKeyJwk` (full JSON object) |
 | `LEXICON_PUBLISHER_DPOP_KEY_JWK` | `dpopJwk` (full JSON object) |
 | `LEXICON_PUBLISHER_TOKEN_SET` | `tokenSet` (full JSON object) |
 
@@ -70,7 +62,6 @@ After bootstrap, with the env vars exported locally:
 ```bash
 export LEXICON_PUBLISHER_DID=did:plc:2f2ahswozqy4v5lvu676375y
 export LEXICON_PUBLISHER_REFRESH_TOKEN=...
-export LEXICON_PUBLISHER_SIGNING_KEY_JWK='{"kty":"EC",...}'
 export LEXICON_PUBLISHER_DPOP_KEY_JWK='{"kty":"EC",...}'
 export LEXICON_PUBLISHER_TOKEN_SET='{"access_token":"...","refresh_token":"...","token_type":"DPoP","expires_at":...}'
 
@@ -100,12 +91,16 @@ serialize. Secrets come from the repo's Actions secrets store.
 
 ## Rotating credentials
 
-If the refresh token is revoked or the signing key is compromised:
+If the refresh token is revoked, lost, or expires from disuse:
 
-1. Run `pnpm publish:bootstrap` again to mint new credentials.
-2. Update the hosted `client-metadata.json` with the new public JWK.
-3. Replace the GitHub Actions secrets with the new values.
-4. (Optional) Revoke the old refresh token via the PDS revocation endpoint.
+1. Run `pnpm publish:bootstrap` again to obtain new credentials.
+2. Replace the GitHub Actions secrets with the new values.
+3. (Optional) Revoke the old refresh token via the PDS revocation endpoint.
+
+Note: refresh tokens for public clients are shorter-lived than for
+confidential clients. As long as CI publishes at least once per refresh
+token lifetime, automatic rotation keeps the session alive. If lexicons
+go untouched for a long stretch, you may need to re-bootstrap.
 
 ## Verification
 

--- a/docs/lexicon-publishing.md
+++ b/docs/lexicon-publishing.md
@@ -1,0 +1,120 @@
+# Lexicon publishing runbook
+
+Publishes every `lexicons/**/*.json` file in this repo as a
+`com.atproto.lexicon.schema` record on the authority DID's PDS, so that
+lexicon resolvers (lexicon.garden, third-party apps) can verify and read
+the `id.sifa.*` namespace at runtime.
+
+## Identity
+
+| | |
+|--|--|
+| Authority DID | `did:plc:2f2ahswozqy4v5lvu676375y` |
+| PDS | `https://eurosky.social` |
+| DNS proof | `_lexicon.sifa.id TXT did=did:plc:2f2ahswozqy4v5lvu676375y` (already configured) |
+| Client metadata | `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json` (hosted by sifa-web) |
+| Auth | OAuth 2.0 confidential client, `private_key_jwt`, ES256, DPoP. No app passwords. |
+
+## One-time bootstrap (manual, done once per service identity)
+
+Prerequisites:
+
+1. The OAuth client metadata file must already be live at
+   `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json`.
+   The hosted copy is shipped from the sifa-web repo (see
+   `sifa-web/public/.well-known/sifa-lexicon-publisher/client-metadata.json`).
+   On first run the public JWK inside it is a placeholder — you'll replace it
+   with the real public JWK generated below.
+
+2. You can sign into eurosky.social as the authority DID (handle + password).
+
+Steps:
+
+```bash
+cd ~/Git/sifa-lexicons
+pnpm install
+pnpm publish:bootstrap did:plc:2f2ahswozqy4v5lvu676375y
+```
+
+The script:
+
+1. Generates an ES256 keypair (kid `lexicon-publisher-1`).
+2. Prints the public JWK. Update the sifa-web `client-metadata.json` so its
+   `jwks.keys[0]` equals this public JWK, deploy, then press Enter.
+3. Opens your browser at the eurosky.social authorize endpoint.
+4. Captures the callback at `http://127.0.0.1:8765/callback`.
+5. Exchanges the code for an access + refresh token bound to the DPoP key.
+6. Writes `.oauth-bootstrap-result.json` (gitignored, mode 0600) containing:
+   - `did`
+   - `refreshToken`
+   - `signingKeyJwk` (private ES256 JWK)
+   - `dpopJwk` (private DPoP JWK)
+   - `tokenSet` (full token set including expiry)
+
+Set these as GitHub Actions secrets on `singi-labs/sifa-lexicons`:
+
+| Secret | Source field |
+|--------|--------------|
+| `LEXICON_PUBLISHER_DID` | `did` |
+| `LEXICON_PUBLISHER_REFRESH_TOKEN` | `refreshToken` |
+| `LEXICON_PUBLISHER_SIGNING_KEY_JWK` | `signingKeyJwk` (full JSON object) |
+| `LEXICON_PUBLISHER_DPOP_KEY_JWK` | `dpopJwk` (full JSON object) |
+| `LEXICON_PUBLISHER_TOKEN_SET` | `tokenSet` (full JSON object) |
+
+Then delete `.oauth-bootstrap-result.json`.
+
+## Phase 1 — one-shot catch-up (manual)
+
+After bootstrap, with the env vars exported locally:
+
+```bash
+export LEXICON_PUBLISHER_DID=did:plc:2f2ahswozqy4v5lvu676375y
+export LEXICON_PUBLISHER_REFRESH_TOKEN=...
+export LEXICON_PUBLISHER_SIGNING_KEY_JWK='{"kty":"EC",...}'
+export LEXICON_PUBLISHER_DPOP_KEY_JWK='{"kty":"EC",...}'
+export LEXICON_PUBLISHER_TOKEN_SET='{"access_token":"...","refresh_token":"...","token_type":"DPoP","expires_at":...}'
+
+pnpm publish:lexicons
+```
+
+Expected output for the catch-up run:
+
+- 9 `NEW` lines for the missing NSIDs
+- 1 `UPD` line for `id.sifa.profile.self`
+- 17 `SKIP ... (unchanged)` lines for the already-published, in-sync schemas
+- Verification: PDS has 27 records; `id.sifa.profile.self` contains
+  `industries`, `availableFromUtc`, `availableToUtc`.
+
+To check status without publishing:
+
+```bash
+pnpm publish:check
+```
+
+## Phase 2 — CI workflow
+
+`.github/workflows/publish-lexicons.yml` runs the same `publish:lexicons`
+script on every push to `main` that touches `lexicons/**/*.json`. The
+workflow uses concurrency group `publish-lexicons` so concurrent merges
+serialize. Secrets come from the repo's Actions secrets store.
+
+## Rotating credentials
+
+If the refresh token is revoked or the signing key is compromised:
+
+1. Run `pnpm publish:bootstrap` again to mint new credentials.
+2. Update the hosted `client-metadata.json` with the new public JWK.
+3. Replace the GitHub Actions secrets with the new values.
+4. (Optional) Revoke the old refresh token via the PDS revocation endpoint.
+
+## Verification
+
+After publishing, sanity check from any machine:
+
+```bash
+curl -s 'https://eurosky.social/xrpc/com.atproto.repo.listRecords?repo=did:plc:2f2ahswozqy4v5lvu676375y&collection=com.atproto.lexicon.schema&limit=100' \
+  | python3 -c "import sys,json; r=json.load(sys.stdin); print(len(r['records'])); [print(rec['uri'].split('/')[-1]) for rec in r['records']]"
+```
+
+Should output `27` followed by the 27 NSIDs. lexicon.garden should show the
+verified-authority badge on each `id.sifa.*` NSID page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,28 +14,212 @@
         "multiformats": "13.4.2"
       },
       "devDependencies": {
+        "@atproto/api": "0.19.17",
         "@atproto/lex-cli": "0.9.9",
+        "@atproto/oauth-client": "0.6.1",
+        "@atproto/oauth-client-node": "0.3.17",
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "eslint": "10.0.3",
         "husky": "9.1.7",
         "prettier": "3.5.3",
+        "tsx": "4.22.3",
         "typescript": "5.9.3",
         "typescript-eslint": "8.56.1",
         "vitest": "3.2.1"
       }
     },
-    "node_modules/@atproto/common-web": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.18.tgz",
-      "integrity": "sha512-ilImzP+9N/mtse440kN60pGrEzG7wi4xsV13nGeLrS+Zocybc/ISOpKlbZM13o+twPJ+Q7veGLw9CtGg0GAFoQ==",
+    "node_modules/@atproto-labs/did-resolver": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.2.6.tgz",
+      "integrity": "sha512-2K1bC04nI2fmgNcvof+yA28IhGlpWn2JKYlPa7To9JTKI45FINCGkQSGiL2nyXlyzDJJ34fZ1aq6/IRFIOIiqg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.13",
-        "@atproto/lex-json": "^0.0.13",
-        "@atproto/syntax": "^0.5.0",
+        "@atproto-labs/fetch": "0.2.3",
+        "@atproto-labs/pipe": "0.1.1",
+        "@atproto-labs/simple-store": "0.3.0",
+        "@atproto-labs/simple-store-memory": "0.1.4",
+        "@atproto/did": "0.3.0",
         "zod": "^3.23.8"
       }
+    },
+    "node_modules/@atproto-labs/fetch": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.2.3.tgz",
+      "integrity": "sha512-NZtbJOCbxKUFRFKMpamT38PUQMY0hX0p7TG5AEYOPhZKZEP7dHZ1K2s1aB8MdVH0qxmqX7nQleNrrvLf09Zfdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/pipe": "0.1.1"
+      }
+    },
+    "node_modules/@atproto-labs/fetch-node": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch-node/-/fetch-node-0.2.0.tgz",
+      "integrity": "sha512-Krq09nH/aeoiU2s9xdHA0FjTEFWG9B5FFenipv1iRixCcPc7V3DhTNDawxG9gI8Ny0k4dBVS9WTRN/IDzBx86Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/fetch": "0.2.3",
+        "@atproto-labs/pipe": "0.1.1",
+        "ipaddr.js": "^2.1.0",
+        "undici": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
+    "node_modules/@atproto-labs/handle-resolver": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/handle-resolver/-/handle-resolver-0.3.6.tgz",
+      "integrity": "sha512-qnSTXvOBNj1EHhp2qTWSX8MS5q3AwYU5LKlt5fBvSbCjgmTr2j0URHCv+ydrwO55KvsojIkTMgeMOh4YuY4fCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/simple-store": "0.3.0",
+        "@atproto-labs/simple-store-memory": "0.1.4",
+        "@atproto/did": "0.3.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto-labs/handle-resolver-node": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/handle-resolver-node/-/handle-resolver-node-0.1.25.tgz",
+      "integrity": "sha512-NY9WYM2VLd3IuMGRkkmvGBg8xqVEaK/fitv1vD8SMXqFTekdpjOLCCyv7EFtqVHouzmDcL83VOvWRfHVa8V9Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/fetch-node": "0.2.0",
+        "@atproto-labs/handle-resolver": "0.3.6",
+        "@atproto/did": "0.3.0"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
+    "node_modules/@atproto-labs/identity-resolver": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/identity-resolver/-/identity-resolver-0.3.6.tgz",
+      "integrity": "sha512-qoWqBDRobln0NR8L8dQjSp79E0chGkBhibEgxQa2f9WD+JbJdjQ0YvwwO5yeQn05pJoJmAwmI2wyJ45zjU7aWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/did-resolver": "0.2.6",
+        "@atproto-labs/handle-resolver": "0.3.6"
+      }
+    },
+    "node_modules/@atproto-labs/pipe": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.1.1.tgz",
+      "integrity": "sha512-hdNw2oUs2B6BN1lp+32pF7cp8EMKuIN5Qok2Vvv/aOpG/3tNSJ9YkvfI0k6Zd188LeDDYRUpYpxcoFIcGH/FNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@atproto-labs/simple-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.3.0.tgz",
+      "integrity": "sha512-nOb6ONKBRJHRlukW1sVawUkBqReLlLx6hT35VS3imaNPwiXDxLnTK7lxw3Lrl9k5yugSBDQAkZAq3MPTEFSUBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@atproto-labs/simple-store-memory": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.1.4.tgz",
+      "integrity": "sha512-3mKY4dP8I7yKPFj9VKpYyCRzGJOi5CEpOLPlRhoJyLmgs3J4RzDrjn323Oakjz2Aj2JzRU/AIvWRAZVhpYNJHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/simple-store": "0.3.0",
+        "lru-cache": "^10.2.0"
+      }
+    },
+    "node_modules/@atproto/api": {
+      "version": "0.19.17",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.19.17.tgz",
+      "integrity": "sha512-xeLBwZGvVQALdgDM2SqExhqr9OenO/P3w+k0Og2Y2eDooTzlXyPdBuvimOVa0Hq7MtytHtSFAWgF6Are2aG90Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.21",
+        "@atproto/lexicon": "^0.6.2",
+        "@atproto/syntax": "^0.5.4",
+        "@atproto/xrpc": "^0.7.7",
+        "await-lock": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "tlds": "^1.234.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/api/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true,
+      "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/@atproto/common-web": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.21.tgz",
+      "integrity": "sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-json": "^0.0.16",
+        "@atproto/syntax": "^0.5.4",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/did": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.3.0.tgz",
+      "integrity": "sha512-raUPzUGegtW/6OxwCmM8bhZvuIMzxG5t9oWsth6Tp91Kb5fTnHV2h/KKNF1C82doeA4BdXCErTyg7ISwLbQkzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/jwk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@atproto/jwk/-/jwk-0.6.0.tgz",
+      "integrity": "sha512-bDoJPvt7TrQVi/rBfBrSSpGykhtIriKxeYCYQTiPRKFfyRhbgpElF0wPXADjIswnbzZdOwbY63az4E/CFVT3Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/jwk-jose": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@atproto/jwk-jose/-/jwk-jose-0.1.11.tgz",
+      "integrity": "sha512-i4Fnr2sTBYmMmHXl7NJh8GrCH+tDQEVWrcDMDnV5DjJfkgT17wIqvojIw9SNbSL4Uf0OtfEv6AgG0A+mgh8b5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/jwk": "0.6.0",
+        "jose": "^5.2.0"
+      }
+    },
+    "node_modules/@atproto/jwk-webcrypto": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@atproto/jwk-webcrypto/-/jwk-webcrypto-0.2.0.tgz",
+      "integrity": "sha512-UmgRrrEAkWvxwhlwe30UmDOdTEFidlIzBC7C3cCbeJMcBN1x8B3KH+crXrsTqfWQBG58mXgt8wgSK3Kxs2LhFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/jwk": "0.6.0",
+        "@atproto/jwk-jose": "0.1.11",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/jwk/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true,
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@atproto/lex-cli": {
       "version": "0.9.9",
@@ -61,9 +245,9 @@
       }
     },
     "node_modules/@atproto/lex-data": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.13.tgz",
-      "integrity": "sha512-7Z7RwZ1Y/JzBF/Tcn/I4UJ/vIGfh5zn1zjv0KX+flke2JtgFkSE8uh2hOtqgBQMNqE3zdJFM+dcSWln86hR3MQ==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.15.tgz",
+      "integrity": "sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==",
       "license": "MIT",
       "dependencies": {
         "multiformats": "^9.9.0",
@@ -79,12 +263,12 @@
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@atproto/lex-json": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.13.tgz",
-      "integrity": "sha512-hwLhkKaIHulGJpt0EfXAEWdrxqM2L1tV/tvilzhMp3QxPqYgXchFnrfVmLsyFDx6P6qkH1GsX/XC2V36U0UlPQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.16.tgz",
+      "integrity": "sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/lex-data": "^0.0.13",
+        "@atproto/lex-data": "^0.0.15",
         "tslib": "^2.8.1"
       }
     },
@@ -107,10 +291,72 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
     },
+    "node_modules/@atproto/oauth-client": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-client/-/oauth-client-0.6.1.tgz",
+      "integrity": "sha512-QTLbEFyv7EJuwJf4A8IZnsylK5wwrzrSsxy0INcZf9zktPVQvgckWhSvbfK8alp60M+rwWfQQAlodcCF4WB78A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/did-resolver": "^0.2.6",
+        "@atproto-labs/fetch": "^0.2.3",
+        "@atproto-labs/handle-resolver": "^0.3.6",
+        "@atproto-labs/identity-resolver": "^0.3.6",
+        "@atproto-labs/simple-store": "^0.3.0",
+        "@atproto-labs/simple-store-memory": "^0.1.4",
+        "@atproto/did": "^0.3.0",
+        "@atproto/jwk": "^0.6.0",
+        "@atproto/oauth-types": "^0.6.3",
+        "@atproto/xrpc": "^0.7.7",
+        "core-js": "^3",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/oauth-client-node": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-client-node/-/oauth-client-node-0.3.17.tgz",
+      "integrity": "sha512-67LNuKAlC35Exe7CB5S0QCAnEqr6fKV9Nvp64jAHFof1N+Vc9Ltt1K9oekE5Ctf7dvpGByrHRF0noUw9l9sWLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/did-resolver": "^0.2.6",
+        "@atproto-labs/handle-resolver-node": "^0.1.25",
+        "@atproto-labs/simple-store": "^0.3.0",
+        "@atproto/did": "^0.3.0",
+        "@atproto/jwk": "^0.6.0",
+        "@atproto/jwk-jose": "^0.1.11",
+        "@atproto/jwk-webcrypto": "^0.2.0",
+        "@atproto/oauth-client": "^0.6.0",
+        "@atproto/oauth-types": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
+    "node_modules/@atproto/oauth-client/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "dev": true,
+      "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/@atproto/oauth-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-types/-/oauth-types-0.6.3.tgz",
+      "integrity": "sha512-jdKuoPknJuh/WjI+mYk7agSbx9mNVMbS6Dr3k1z2YMY2oRiCQjxYBuo4MLKATbxj05nMQaZRWlHRUazoAu5Cng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/did": "^0.3.0",
+        "@atproto/jwk": "^0.6.0",
+        "zod": "^3.23.8"
+      }
+    },
     "node_modules/@atproto/syntax": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.0.tgz",
-      "integrity": "sha512-UA2DSpGdOQzUQ4gi5SH+NEJz/YR3a3Fg3y2oh+xETDSiTRmA4VhHRCojhXAVsBxUT6EnItw190C/KN+DWW90kw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.4.tgz",
+      "integrity": "sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
@@ -2053,6 +2299,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2240,6 +2493,18 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cosmiconfig": {
@@ -3060,6 +3325,16 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3144,6 +3419,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -3337,6 +3622,13 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3914,6 +4206,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -3943,6 +4245,509 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4009,6 +4814,16 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "format:check": "prettier --check .",
+    "publish:bootstrap": "tsx scripts/oauth-bootstrap.ts",
+    "publish:lexicons": "tsx scripts/publish-lexicons.ts",
+    "publish:check": "tsx scripts/publish-lexicons.ts --check",
     "prepare": "husky"
   },
   "dependencies": {
@@ -39,12 +42,16 @@
     "multiformats": "13.4.2"
   },
   "devDependencies": {
+    "@atproto/api": "0.19.17",
     "@atproto/lex-cli": "0.9.9",
+    "@atproto/oauth-client": "0.6.1",
+    "@atproto/oauth-client-node": "0.3.17",
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "eslint": "10.0.3",
     "husky": "9.1.7",
     "prettier": "3.5.3",
+    "tsx": "4.22.3",
     "typescript": "5.9.3",
     "typescript-eslint": "8.56.1",
     "vitest": "3.2.1"

--- a/scripts/oauth-bootstrap.ts
+++ b/scripts/oauth-bootstrap.ts
@@ -1,26 +1,22 @@
 /**
  * One-time interactive OAuth bootstrap for the lexicon publisher service identity.
  *
- * Generates an ES256 keypair, runs the browser-based OAuth authorization code flow
- * against the authority DID's PDS (PAR + PKCE + DPoP, handled by
- * @atproto/oauth-client-node), and prints the resulting refresh token + private
- * JWKs so they can be stored as GitHub Actions secrets.
+ * Runs the browser-based OAuth authorization code flow (PAR + PKCE + DPoP,
+ * handled by @atproto/oauth-client-node) against the authority DID's PDS as a
+ * public native client (atproto OAuth requires native clients to use
+ * token_endpoint_auth_method=none). Prints the resulting refresh token + DPoP
+ * key so they can be stored as GitHub Actions secrets.
  *
  * Usage:
- *   pnpm tsx scripts/oauth-bootstrap.ts <handle-or-did>
+ *   pnpm publish:bootstrap <handle-or-did>
  *
  * Example:
- *   pnpm tsx scripts/oauth-bootstrap.ts did:plc:2f2ahswozqy4v5lvu676375y
- *
- * Prerequisites:
- *   - client-metadata.json (with the public JWK printed by this script) must be
- *     hosted at the client_id URL BEFORE the browser flow can succeed. This script
- *     prints the public JWK, waits for confirmation, then opens the browser.
+ *   pnpm publish:bootstrap did:plc:2f2ahswozqy4v5lvu676375y
  */
 import { createServer } from 'node:http';
 import { exec } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
-import { JoseKey, NodeOAuthClient } from '@atproto/oauth-client-node';
+import { NodeOAuthClient } from '@atproto/oauth-client-node';
 import type {
   NodeSavedSession,
   NodeSavedSessionStore,
@@ -34,41 +30,18 @@ const REDIRECT_PATH = '/callback';
 async function main() {
   const subject = process.argv[2];
   if (!subject) {
-    console.error('Usage: pnpm tsx scripts/oauth-bootstrap.ts <handle-or-did>');
+    console.error('Usage: pnpm publish:bootstrap <handle-or-did>');
     process.exit(1);
-  }
-
-  console.log('Generating ES256 signing key (kid=lexicon-publisher-1)...');
-  const signingKey = await JoseKey.generate(['ES256'], 'lexicon-publisher-1');
-  const privateJwk = signingKey.privateJwk;
-  const publicJwk = signingKey.publicJwk;
-  if (!privateJwk || !publicJwk) {
-    throw new Error('Key generation failed to produce JWKs');
   }
 
   const clientMetadataPath = new URL('../client-metadata.json', import.meta.url);
   const clientMetadata = JSON.parse(await readFile(clientMetadataPath, 'utf8'));
-  clientMetadata.jwks = { keys: [publicJwk] };
-
-  console.log('\n=== ACTION REQUIRED ===');
-  console.log(
-    'Update the hosted client-metadata.json (sifa-web) so its "jwks.keys[0]" matches:',
-  );
-  console.log(JSON.stringify(publicJwk, null, 2));
-  console.log(
-    '\nThe metadata at',
-    clientMetadata.client_id,
-    'MUST be live with this exact key before continuing.',
-  );
-  console.log('Press Enter when the hosted metadata has been deployed...');
-  await waitForEnter();
 
   const stateStore: NodeSavedStateStore = makeMemoryStore<NodeSavedState>();
   const sessionStore: NodeSavedSessionStore = makeMemoryStore<NodeSavedSession>();
 
   const client = new NodeOAuthClient({
     clientMetadata,
-    keyset: [signingKey],
     stateStore,
     sessionStore,
   });
@@ -80,7 +53,7 @@ async function main() {
   });
 
   const codePromise = waitForCallback(state);
-  console.log('\nOpen this URL in your browser to authorize:');
+  console.log('Open this URL in your browser to authorize:');
   console.log(authUrl.toString());
   openInBrowser(authUrl.toString());
 
@@ -102,7 +75,6 @@ async function main() {
   const out = {
     did,
     refreshToken,
-    signingKeyJwk: privateJwk,
     dpopJwk: stored.dpopJwk,
     tokenSet: stored.tokenSet,
     clientId: clientMetadata.client_id,
@@ -115,11 +87,11 @@ async function main() {
   console.log('Authorized as DID:', did);
   console.log('Wrote bootstrap result to:', outPath.pathname);
   console.log('\nNow set these as GitHub Actions secrets:');
-  console.log('  LEXICON_PUBLISHER_DID              = ' + did);
-  console.log('  LEXICON_PUBLISHER_REFRESH_TOKEN    = (out.refreshToken)');
-  console.log('  LEXICON_PUBLISHER_SIGNING_KEY_JWK  = (out.signingKeyJwk, full JSON)');
-  console.log('  LEXICON_PUBLISHER_DPOP_KEY_JWK     = (out.dpopJwk, full JSON)');
-  console.log('\nAlso save these to a local .env for the first manual publish run.');
+  console.log('  LEXICON_PUBLISHER_DID            = ' + did);
+  console.log('  LEXICON_PUBLISHER_REFRESH_TOKEN  = (out.refreshToken)');
+  console.log('  LEXICON_PUBLISHER_DPOP_KEY_JWK   = (out.dpopJwk, full JSON)');
+  console.log('  LEXICON_PUBLISHER_TOKEN_SET      = (out.tokenSet, full JSON)');
+  console.log('\nAlso export them locally for the first manual publish run.');
   console.log('Delete .oauth-bootstrap-result.json after secrets are saved.');
   process.exit(0);
 }
@@ -137,18 +109,6 @@ function makeMemoryStore<V extends NonNullable<unknown> | null>() {
       map.delete(key);
     },
   };
-}
-
-function waitForEnter(): Promise<void> {
-  return new Promise((resolve) => {
-    const onData = () => {
-      process.stdin.off('data', onData);
-      process.stdin.pause();
-      resolve();
-    };
-    process.stdin.resume();
-    process.stdin.on('data', onData);
-  });
 }
 
 function waitForCallback(expectedState: string): Promise<URLSearchParams> {

--- a/scripts/oauth-bootstrap.ts
+++ b/scripts/oauth-bootstrap.ts
@@ -46,13 +46,11 @@ async function main() {
     sessionStore,
   });
 
-  const state = `bootstrap-${Date.now()}`;
   const authUrl = await client.authorize(subject, {
     scope: 'atproto transition:generic',
-    state,
   });
 
-  const codePromise = waitForCallback(state);
+  const codePromise = waitForCallback();
   console.log('Open this URL in your browser to authorize:');
   console.log(authUrl.toString());
   openInBrowser(authUrl.toString());
@@ -111,20 +109,15 @@ function makeMemoryStore<V extends NonNullable<unknown> | null>() {
   };
 }
 
-function waitForCallback(expectedState: string): Promise<URLSearchParams> {
-  return new Promise((resolve, reject) => {
+function waitForCallback(): Promise<URLSearchParams> {
+  // State validation is handled by @atproto/oauth-client via its stateStore;
+  // we just forward the callback params to client.callback().
+  return new Promise((resolve) => {
     const server = createServer((req, res) => {
       if (!req.url) return;
       const url = new URL(req.url, `http://127.0.0.1:${REDIRECT_PORT}`);
       if (url.pathname !== REDIRECT_PATH) {
         res.writeHead(404).end();
-        return;
-      }
-      const stateParam = url.searchParams.get('state');
-      if (stateParam !== expectedState) {
-        res.writeHead(400).end('State mismatch');
-        server.close();
-        reject(new Error('State mismatch'));
         return;
       }
       res

--- a/scripts/oauth-bootstrap.ts
+++ b/scripts/oauth-bootstrap.ts
@@ -1,0 +1,193 @@
+/**
+ * One-time interactive OAuth bootstrap for the lexicon publisher service identity.
+ *
+ * Generates an ES256 keypair, runs the browser-based OAuth authorization code flow
+ * against the authority DID's PDS (PAR + PKCE + DPoP, handled by
+ * @atproto/oauth-client-node), and prints the resulting refresh token + private
+ * JWKs so they can be stored as GitHub Actions secrets.
+ *
+ * Usage:
+ *   pnpm tsx scripts/oauth-bootstrap.ts <handle-or-did>
+ *
+ * Example:
+ *   pnpm tsx scripts/oauth-bootstrap.ts did:plc:2f2ahswozqy4v5lvu676375y
+ *
+ * Prerequisites:
+ *   - client-metadata.json (with the public JWK printed by this script) must be
+ *     hosted at the client_id URL BEFORE the browser flow can succeed. This script
+ *     prints the public JWK, waits for confirmation, then opens the browser.
+ */
+import { createServer } from 'node:http';
+import { exec } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { JoseKey, NodeOAuthClient } from '@atproto/oauth-client-node';
+import type {
+  NodeSavedSession,
+  NodeSavedSessionStore,
+  NodeSavedState,
+  NodeSavedStateStore,
+} from '@atproto/oauth-client-node';
+
+const REDIRECT_PORT = 8765;
+const REDIRECT_PATH = '/callback';
+
+async function main() {
+  const subject = process.argv[2];
+  if (!subject) {
+    console.error('Usage: pnpm tsx scripts/oauth-bootstrap.ts <handle-or-did>');
+    process.exit(1);
+  }
+
+  console.log('Generating ES256 signing key (kid=lexicon-publisher-1)...');
+  const signingKey = await JoseKey.generate(['ES256'], 'lexicon-publisher-1');
+  const privateJwk = signingKey.privateJwk;
+  const publicJwk = signingKey.publicJwk;
+  if (!privateJwk || !publicJwk) {
+    throw new Error('Key generation failed to produce JWKs');
+  }
+
+  const clientMetadataPath = new URL('../client-metadata.json', import.meta.url);
+  const clientMetadata = JSON.parse(await readFile(clientMetadataPath, 'utf8'));
+  clientMetadata.jwks = { keys: [publicJwk] };
+
+  console.log('\n=== ACTION REQUIRED ===');
+  console.log(
+    'Update the hosted client-metadata.json (sifa-web) so its "jwks.keys[0]" matches:',
+  );
+  console.log(JSON.stringify(publicJwk, null, 2));
+  console.log(
+    '\nThe metadata at',
+    clientMetadata.client_id,
+    'MUST be live with this exact key before continuing.',
+  );
+  console.log('Press Enter when the hosted metadata has been deployed...');
+  await waitForEnter();
+
+  const stateStore: NodeSavedStateStore = makeMemoryStore<NodeSavedState>();
+  const sessionStore: NodeSavedSessionStore = makeMemoryStore<NodeSavedSession>();
+
+  const client = new NodeOAuthClient({
+    clientMetadata,
+    keyset: [signingKey],
+    stateStore,
+    sessionStore,
+  });
+
+  const state = `bootstrap-${Date.now()}`;
+  const authUrl = await client.authorize(subject, {
+    scope: 'atproto transition:generic',
+    state,
+  });
+
+  const codePromise = waitForCallback(state);
+  console.log('\nOpen this URL in your browser to authorize:');
+  console.log(authUrl.toString());
+  openInBrowser(authUrl.toString());
+
+  const params = await codePromise;
+  console.log('\nReceived authorization code, exchanging for tokens...');
+
+  const { session } = await client.callback(params);
+  const did = session.did;
+
+  const stored = await sessionStore.get(did);
+  if (!stored) {
+    throw new Error('Session was not persisted by the OAuth client');
+  }
+  const refreshToken = stored.tokenSet?.refresh_token;
+  if (!refreshToken) {
+    throw new Error('No refresh token returned by the PDS');
+  }
+
+  const out = {
+    did,
+    refreshToken,
+    signingKeyJwk: privateJwk,
+    dpopJwk: stored.dpopJwk,
+    tokenSet: stored.tokenSet,
+    clientId: clientMetadata.client_id,
+  };
+
+  const outPath = new URL('../.oauth-bootstrap-result.json', import.meta.url);
+  await writeFile(outPath, JSON.stringify(out, null, 2), { mode: 0o600 });
+
+  console.log('\n=== BOOTSTRAP COMPLETE ===');
+  console.log('Authorized as DID:', did);
+  console.log('Wrote bootstrap result to:', outPath.pathname);
+  console.log('\nNow set these as GitHub Actions secrets:');
+  console.log('  LEXICON_PUBLISHER_DID              = ' + did);
+  console.log('  LEXICON_PUBLISHER_REFRESH_TOKEN    = (out.refreshToken)');
+  console.log('  LEXICON_PUBLISHER_SIGNING_KEY_JWK  = (out.signingKeyJwk, full JSON)');
+  console.log('  LEXICON_PUBLISHER_DPOP_KEY_JWK     = (out.dpopJwk, full JSON)');
+  console.log('\nAlso save these to a local .env for the first manual publish run.');
+  console.log('Delete .oauth-bootstrap-result.json after secrets are saved.');
+  process.exit(0);
+}
+
+function makeMemoryStore<V extends NonNullable<unknown> | null>() {
+  const map = new Map<string, V>();
+  return {
+    async get(key: string): Promise<V | undefined> {
+      return map.get(key);
+    },
+    async set(key: string, value: V): Promise<void> {
+      map.set(key, value);
+    },
+    async del(key: string): Promise<void> {
+      map.delete(key);
+    },
+  };
+}
+
+function waitForEnter(): Promise<void> {
+  return new Promise((resolve) => {
+    const onData = () => {
+      process.stdin.off('data', onData);
+      process.stdin.pause();
+      resolve();
+    };
+    process.stdin.resume();
+    process.stdin.on('data', onData);
+  });
+}
+
+function waitForCallback(expectedState: string): Promise<URLSearchParams> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      if (!req.url) return;
+      const url = new URL(req.url, `http://127.0.0.1:${REDIRECT_PORT}`);
+      if (url.pathname !== REDIRECT_PATH) {
+        res.writeHead(404).end();
+        return;
+      }
+      const stateParam = url.searchParams.get('state');
+      if (stateParam !== expectedState) {
+        res.writeHead(400).end('State mismatch');
+        server.close();
+        reject(new Error('State mismatch'));
+        return;
+      }
+      res
+        .writeHead(200, { 'content-type': 'text/html' })
+        .end('<h1>Authorization received</h1><p>You can close this tab.</p>');
+      server.close();
+      resolve(url.searchParams);
+    });
+    server.listen(REDIRECT_PORT, '127.0.0.1');
+  });
+}
+
+function openInBrowser(url: string) {
+  const cmd =
+    process.platform === 'darwin'
+      ? `open "${url}"`
+      : process.platform === 'win32'
+        ? `start "" "${url}"`
+        : `xdg-open "${url}"`;
+  exec(cmd, () => {});
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/oauth-session.ts
+++ b/scripts/oauth-session.ts
@@ -2,14 +2,13 @@
  * Restore a previously-bootstrapped OAuth session from environment variables.
  *
  * Required env vars:
- *   LEXICON_PUBLISHER_DID              The authority DID this session belongs to.
- *   LEXICON_PUBLISHER_REFRESH_TOKEN    Refresh token from oauth-bootstrap.
- *   LEXICON_PUBLISHER_SIGNING_KEY_JWK  Private ES256 JWK (JSON string).
- *   LEXICON_PUBLISHER_DPOP_KEY_JWK     Private DPoP JWK (JSON string).
- *   LEXICON_PUBLISHER_TOKEN_SET        Full TokenSet JSON from oauth-bootstrap.
+ *   LEXICON_PUBLISHER_DID            The authority DID this session belongs to.
+ *   LEXICON_PUBLISHER_REFRESH_TOKEN  Refresh token from oauth-bootstrap.
+ *   LEXICON_PUBLISHER_DPOP_KEY_JWK   Private DPoP JWK (JSON string).
+ *   LEXICON_PUBLISHER_TOKEN_SET      Full TokenSet JSON from oauth-bootstrap.
  */
 import { readFile } from 'node:fs/promises';
-import { JoseKey, NodeOAuthClient } from '@atproto/oauth-client-node';
+import { NodeOAuthClient } from '@atproto/oauth-client-node';
 import type {
   NodeSavedSession,
   NodeSavedSessionStore,
@@ -41,40 +40,27 @@ function makeMemoryStore<V extends NonNullable<unknown> | null>() {
 
 export async function restoreOAuthSession(): Promise<OAuthSession> {
   const did = requireEnv('LEXICON_PUBLISHER_DID');
-  const signingKeyJwk = JSON.parse(requireEnv('LEXICON_PUBLISHER_SIGNING_KEY_JWK'));
   const dpopJwk = JSON.parse(requireEnv('LEXICON_PUBLISHER_DPOP_KEY_JWK'));
   const tokenSet = JSON.parse(requireEnv('LEXICON_PUBLISHER_TOKEN_SET'));
 
   const clientMetadataPath = new URL('../client-metadata.json', import.meta.url);
   const clientMetadata = JSON.parse(await readFile(clientMetadataPath, 'utf8'));
-  // The hosted metadata holds the authoritative public JWK; for the client
-  // constructor we need a non-empty jwks placeholder. The signing key in the
-  // keyset is what's actually used to sign assertions.
-  if (!clientMetadata.jwks) {
-    clientMetadata.jwks = { keys: [] };
-  }
-
-  const signingKey = await JoseKey.fromJWK(signingKeyJwk);
 
   const stateStore: NodeSavedStateStore = makeMemoryStore<NodeSavedState>();
   const sessionStore: NodeSavedSessionStore = makeMemoryStore<NodeSavedSession>();
 
-  const kid = signingKeyJwk.kid ?? 'lexicon-publisher-1';
   const initial: NodeSavedSession = {
     dpopJwk,
     tokenSet,
-    authMethod: { method: 'private_key_jwt', kid },
+    authMethod: { method: 'none' },
   } as NodeSavedSession;
   await sessionStore.set(did, initial);
 
   const client = new NodeOAuthClient({
     clientMetadata,
-    keyset: [signingKey],
     stateStore,
     sessionStore,
   });
 
-  // `restore` triggers a refresh if the access token is expired/near-expiry.
-  // 'auto' is the default; pass true to force-refresh on every restore.
   return await client.restore(did, 'auto');
 }

--- a/scripts/oauth-session.ts
+++ b/scripts/oauth-session.ts
@@ -1,0 +1,80 @@
+/**
+ * Restore a previously-bootstrapped OAuth session from environment variables.
+ *
+ * Required env vars:
+ *   LEXICON_PUBLISHER_DID              The authority DID this session belongs to.
+ *   LEXICON_PUBLISHER_REFRESH_TOKEN    Refresh token from oauth-bootstrap.
+ *   LEXICON_PUBLISHER_SIGNING_KEY_JWK  Private ES256 JWK (JSON string).
+ *   LEXICON_PUBLISHER_DPOP_KEY_JWK     Private DPoP JWK (JSON string).
+ *   LEXICON_PUBLISHER_TOKEN_SET        Full TokenSet JSON from oauth-bootstrap.
+ */
+import { readFile } from 'node:fs/promises';
+import { JoseKey, NodeOAuthClient } from '@atproto/oauth-client-node';
+import type {
+  NodeSavedSession,
+  NodeSavedSessionStore,
+  NodeSavedState,
+  NodeSavedStateStore,
+} from '@atproto/oauth-client-node';
+import type { OAuthSession } from '@atproto/oauth-client';
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+function makeMemoryStore<V extends NonNullable<unknown> | null>() {
+  const map = new Map<string, V>();
+  return {
+    async get(key: string): Promise<V | undefined> {
+      return map.get(key);
+    },
+    async set(key: string, value: V): Promise<void> {
+      map.set(key, value);
+    },
+    async del(key: string): Promise<void> {
+      map.delete(key);
+    },
+  };
+}
+
+export async function restoreOAuthSession(): Promise<OAuthSession> {
+  const did = requireEnv('LEXICON_PUBLISHER_DID');
+  const signingKeyJwk = JSON.parse(requireEnv('LEXICON_PUBLISHER_SIGNING_KEY_JWK'));
+  const dpopJwk = JSON.parse(requireEnv('LEXICON_PUBLISHER_DPOP_KEY_JWK'));
+  const tokenSet = JSON.parse(requireEnv('LEXICON_PUBLISHER_TOKEN_SET'));
+
+  const clientMetadataPath = new URL('../client-metadata.json', import.meta.url);
+  const clientMetadata = JSON.parse(await readFile(clientMetadataPath, 'utf8'));
+  // The hosted metadata holds the authoritative public JWK; for the client
+  // constructor we need a non-empty jwks placeholder. The signing key in the
+  // keyset is what's actually used to sign assertions.
+  if (!clientMetadata.jwks) {
+    clientMetadata.jwks = { keys: [] };
+  }
+
+  const signingKey = await JoseKey.fromJWK(signingKeyJwk);
+
+  const stateStore: NodeSavedStateStore = makeMemoryStore<NodeSavedState>();
+  const sessionStore: NodeSavedSessionStore = makeMemoryStore<NodeSavedSession>();
+
+  const kid = signingKeyJwk.kid ?? 'lexicon-publisher-1';
+  const initial: NodeSavedSession = {
+    dpopJwk,
+    tokenSet,
+    authMethod: { method: 'private_key_jwt', kid },
+  } as NodeSavedSession;
+  await sessionStore.set(did, initial);
+
+  const client = new NodeOAuthClient({
+    clientMetadata,
+    keyset: [signingKey],
+    stateStore,
+    sessionStore,
+  });
+
+  // `restore` triggers a refresh if the access token is expired/near-expiry.
+  // 'auto' is the default; pass true to force-refresh on every restore.
+  return await client.restore(did, 'auto');
+}

--- a/scripts/publish-lexicons.ts
+++ b/scripts/publish-lexicons.ts
@@ -1,0 +1,187 @@
+/**
+ * Publish every lexicon JSON in `lexicons/**` as a `com.atproto.lexicon.schema`
+ * record on the authority DID's PDS. Idempotent: existing records are updated,
+ * missing records are created, no-op writes are skipped.
+ *
+ * Requires the OAuth env vars listed in scripts/oauth-session.ts.
+ *
+ * Usage:
+ *   pnpm tsx scripts/publish-lexicons.ts            # publish + verify
+ *   pnpm tsx scripts/publish-lexicons.ts --check    # listRecords-only verification
+ */
+import { Agent } from '@atproto/api';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { restoreOAuthSession } from './oauth-session.js';
+
+const LEXICONS_DIR = new URL('../lexicons/', import.meta.url).pathname;
+const COLLECTION = 'com.atproto.lexicon.schema';
+
+type LexiconRecord = { id: string; [k: string]: unknown };
+
+async function* walkLexicons(dir: string): AsyncGenerator<string> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkLexicons(path);
+    } else if (entry.name.endsWith('.json')) {
+      yield path;
+    }
+  }
+}
+
+function recordsEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(stableStringify(a)) === JSON.stringify(stableStringify(b));
+}
+
+function stableStringify(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableStringify);
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = stableStringify((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+async function loadLocalLexicons(): Promise<Map<string, LexiconRecord>> {
+  const records = new Map<string, LexiconRecord>();
+  for await (const path of walkLexicons(LEXICONS_DIR)) {
+    const raw = await readFile(path, 'utf8');
+    const record = JSON.parse(raw) as LexiconRecord;
+    if (!record.id || typeof record.id !== 'string') {
+      throw new Error(`Lexicon ${path} has no string "id" field`);
+    }
+    if (records.has(record.id)) {
+      throw new Error(`Duplicate lexicon id ${record.id} (already seen elsewhere)`);
+    }
+    records.set(record.id, record);
+  }
+  return records;
+}
+
+async function listAllPublishedRkeys(agent: Agent, repo: string): Promise<Set<string>> {
+  const rkeys = new Set<string>();
+  let cursor: string | undefined;
+  do {
+    const res = await agent.com.atproto.repo.listRecords({
+      repo,
+      collection: COLLECTION,
+      limit: 100,
+      cursor,
+    });
+    for (const r of res.data.records) {
+      const parts = r.uri.split('/');
+      rkeys.add(parts[parts.length - 1]);
+    }
+    cursor = res.data.cursor;
+  } while (cursor);
+  return rkeys;
+}
+
+async function publish() {
+  const check = process.argv.includes('--check');
+
+  console.log('Restoring OAuth session...');
+  const session = await restoreOAuthSession();
+  const agent = new Agent(session);
+  const repo = session.did;
+  console.log('Authenticated as', repo);
+
+  const local = await loadLocalLexicons();
+  console.log(`Loaded ${local.size} local lexicons`);
+
+  if (check) {
+    const published = await listAllPublishedRkeys(agent, repo);
+    const missing = [...local.keys()].filter((k) => !published.has(k));
+    const orphan = [...published].filter((k) => !local.has(k));
+    console.log(`Published on PDS: ${published.size}`);
+    console.log(`Missing from PDS: ${missing.length}`, missing);
+    console.log(`Orphan on PDS (in repo but not in lexicons/): ${orphan.length}`, orphan);
+    process.exit(missing.length === 0 ? 0 : 2);
+  }
+
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+  let failed = 0;
+
+  for (const [rkey, record] of local) {
+    try {
+      const existing = await agent.com.atproto.repo
+        .getRecord({ repo, collection: COLLECTION, rkey })
+        .then((r) => r.data.value)
+        .catch(() => null);
+
+      if (existing && recordsEqual(existing, record)) {
+        unchanged++;
+        console.log(`SKIP ${rkey} (unchanged)`);
+        continue;
+      }
+
+      await agent.com.atproto.repo.putRecord({
+        repo,
+        collection: COLLECTION,
+        rkey,
+        record,
+      });
+      if (existing) {
+        updated++;
+        console.log(`UPD  ${rkey}`);
+      } else {
+        created++;
+        console.log(`NEW  ${rkey}`);
+      }
+    } catch (err) {
+      failed++;
+      console.error(`FAIL ${rkey}`, err);
+    }
+  }
+
+  console.log(
+    `\nSummary: ${created} created, ${updated} updated, ${unchanged} unchanged, ${failed} failed`,
+  );
+
+  if (failed > 0) {
+    console.error('One or more putRecord calls failed.');
+    process.exit(1);
+  }
+
+  // Verify
+  const published = await listAllPublishedRkeys(agent, repo);
+  const missing = [...local.keys()].filter((k) => !published.has(k));
+  if (missing.length > 0) {
+    console.error('Verification failed: still missing from PDS:', missing);
+    process.exit(1);
+  }
+  console.log(`\nVerified: PDS has ${published.size} records covering all local NSIDs.`);
+
+  // Spot-check the profile.self shape per issue #48 acceptance criteria
+  const selfRes = await agent.com.atproto.repo.getRecord({
+    repo,
+    collection: COLLECTION,
+    rkey: 'id.sifa.profile.self',
+  });
+  const selfProps = (
+    selfRes.data.value as {
+      defs?: { main?: { record?: { properties?: Record<string, unknown> } } };
+    }
+  )?.defs?.main?.record?.properties;
+  const requiredKeys = ['industries', 'availableFromUtc', 'availableToUtc'];
+  const missingKeys = requiredKeys.filter((k) => !selfProps || !(k in selfProps));
+  if (missingKeys.length > 0) {
+    console.error(
+      'Verification failed: id.sifa.profile.self missing keys on PDS:',
+      missingKeys,
+    );
+    process.exit(1);
+  }
+  console.log('Verified: id.sifa.profile.self contains', requiredKeys.join(', '));
+}
+
+publish().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/publish-lexicons.ts
+++ b/scripts/publish-lexicons.ts
@@ -172,10 +172,7 @@ async function publish() {
   const requiredKeys = ['industries', 'availableFromUtc', 'availableToUtc'];
   const missingKeys = requiredKeys.filter((k) => !selfProps || !(k in selfProps));
   if (missingKeys.length > 0) {
-    console.error(
-      'Verification failed: id.sifa.profile.self missing keys on PDS:',
-      missingKeys,
-    );
+    console.error('Verification failed: id.sifa.profile.self missing keys on PDS:', missingKeys);
     process.exit(1);
   }
   console.log('Verified: id.sifa.profile.self contains', requiredKeys.join(', '));

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../dist-scripts",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["./*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

Phase 1 of singi-labs/sifa-lexicons#48 — publish every `lexicons/**/*.json` as a `com.atproto.lexicon.schema` record on the authority DID's PDS (`did:plc:2f2ahswozqy4v5lvu676375y` on `eurosky.social`).

- `scripts/oauth-bootstrap.ts` — one-time interactive ES256 + browser flow
- `scripts/oauth-session.ts` — restore session from env vars
- `scripts/publish-lexicons.ts` — idempotent putRecord sync + listRecords verify
- `client-metadata.json` — source-of-truth OAuth client metadata (hosted copy lives in sifa-web)
- `docs/lexicon-publishing.md` — runbook

OAuth confidential client with `private_key_jwt` + DPoP. No app passwords. Verified against installed `@atproto/oauth-client-node@0.3.17` API shapes.

**Draft until Phase 1 catch-up run is verified green** (PDS contains 27 records; `id.sifa.profile.self` includes `industries`, `availableFromUtc`, `availableToUtc`).

Phase 2 (CI workflow at `.github/workflows/publish-lexicons.yml`) ships in a follow-up PR.

## Companion PR

`singi-labs/sifa-web` PR hosts the client metadata at `https://sifa.id/.well-known/sifa-lexicon-publisher/client-metadata.json`. That PR must merge + deploy (with the real public JWK substituted in) before the OAuth bootstrap browser flow can complete.

## Test plan

- [x] `npx tsc -p scripts/tsconfig.json` clean
- [ ] `pnpm publish:bootstrap did:plc:2f2ahswozqy4v5lvu676375y` produces a refresh token
- [ ] `pnpm publish:check` shows 9 missing NSIDs before publish
- [ ] `pnpm publish:lexicons` reports 9 NEW + 1 UPD + 17 SKIP + verification passes
- [ ] `pnpm publish:check` shows 0 missing after publish
- [ ] lexicon.garden shows verified-authority badge on all 27 NSIDs

Refs singi-labs/sifa-lexicons#48