### PR TITLE
docs(readme): link to lexicon.garden authority view

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 
 This package defines the `id.sifa.*` namespace -- the data contract between a user's PDS and the Sifa AppView. Because the schemas live on the protocol layer, all professional profile data (positions, education, skills, endorsements) is portable: users own their data and can move between services without loss.
 
+### Verified authority
+
+Every schema in this repo is published as a `com.atproto.lexicon.schema` record on the namespace authority DID's PDS, with the DNS proof `_lexicon.sifa.id TXT did=did:plc:2f2ahswozqy4v5lvu676375y` in place. Third-party tools that resolve `id.sifa.*` lexicons at runtime get the canonical schema directly from the protocol -- no dependency on this repo being reachable.
+
+[**Browse on lexicon.garden →**](https://lexicon.garden/identity/did:plc:2f2ahswozqy4v5lvu676375y)
+
 ---
 
 ## Lexicon Schemas


### PR DESCRIPTION
## Summary

Short "Verified authority" section under Overview with a link to the lexicon.garden identity page. Third-party developers exploring the repo land on a protocol-level verified view (badge + 27 NSIDs) without taking the README claim on trust.

Follow-up to #48 / #49 — the lexicon publishing infrastructure is now visible to the ecosystem.

## Test plan

- [x] Prettier clean
- [ ] Renders correctly on github.com/singi-labs/sifa-lexicons
- [ ] Link resolves to a page showing all 27 NSIDs with authority-check badges