### PR TITLE
feat(well-known): add activity-tiers taxonomy spec

### DIFF
--- a/well-known/README.md
+++ b/well-known/README.md
@@ -12,11 +12,11 @@ data; it only governs Sifa's own rendering choices.
 
 ## The three tiers
 
-| Tier | Label | Public profile? | What goes here |
-|------|-------|-----------------|----------------|
-| `creation` | "Made" | yes | Substantive authored records: posts, articles, repos, galleries, livestreams, CV entries, RSVPs, comments. |
-| `action` | "Did" | no, owner-only | Engagement: likes, reposts, follows, votes, stars, reactions, short replies. Visible to the actor on `/me/activity`; not shown to others on Sifa. |
-| `filtered` | (none) | no | Infrastructure, configuration, moderation (blocks/mutes/flags), ephemeral consumption signals (bookmarks, highlights), game state, OAuth scope records. Not shown anywhere in Sifa. |
+| Tier       | Label  | Public profile? | What goes here                                                                                                                                                                      |
+| ---------- | ------ | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `creation` | "Made" | yes             | Substantive authored records: posts, articles, repos, galleries, livestreams, CV entries, RSVPs, comments.                                                                          |
+| `action`   | "Did"  | no, owner-only  | Engagement: likes, reposts, follows, votes, stars, reactions, short replies. Visible to the actor on `/me/activity`; not shown to others on Sifa.                                   |
+| `filtered` | (none) | no              | Infrastructure, configuration, moderation (blocks/mutes/flags), ephemeral consumption signals (bookmarks, highlights), game state, OAuth scope records. Not shown anywhere in Sifa. |
 
 Records in `action` and `filtered` still exist on the author's PDS and may be
 displayed by other apps. Sifa simply opts out of rendering them on its own
@@ -62,6 +62,7 @@ const tier = spec.lexicons[nsid]?.tier ?? 'filtered';
 ```
 
 Suggested defaults for NSIDs not listed in the file:
+
 - If the NSID's parent app is registered in `sifa-api`'s registry and not in
   `EXCLUDED_COLLECTIONS`, treat it as `creation`.
 - Otherwise treat it as `filtered`.
@@ -87,10 +88,10 @@ breaking change for consumers and must go through a major bump.
 
 The `version` field follows semver:
 
-| Change | Bump |
-|--------|------|
-| Tier renamed, tier removed, NSID moved between tiers | major |
-| New NSID added, new tier added | minor |
+| Change                                                   | Bump  |
+| -------------------------------------------------------- | ----- |
+| Tier renamed, tier removed, NSID moved between tiers     | major |
+| New NSID added, new tier added                           | minor |
 | Note/typo fix, `app` field change, `updated` field touch | patch |
 
 The current version is `1.0.0`. The `$schema` URL is reserved for a future

--- a/well-known/README.md
+++ b/well-known/README.md
@@ -1,0 +1,134 @@
+# Sifa activity-tiers spec
+
+`activity-tiers.json` is Sifa's canonical mapping of AT Protocol record types
+(NSIDs) to display tiers. It tells Sifa surfaces, third-party clients, and
+sibling AppViews how Sifa categorises a given record when deciding whether to
+show it on a public profile, on the owner-only "What is public about me" page,
+or to hide it entirely from Sifa UI.
+
+It is **editorial**, not protocol. The records themselves remain public on the
+author's PDS regardless of which tier Sifa assigns. This file does not gate
+data; it only governs Sifa's own rendering choices.
+
+## The three tiers
+
+| Tier | Label | Public profile? | What goes here |
+|------|-------|-----------------|----------------|
+| `creation` | "Made" | yes | Substantive authored records: posts, articles, repos, galleries, livestreams, CV entries, RSVPs, comments. |
+| `action` | "Did" | no, owner-only | Engagement: likes, reposts, follows, votes, stars, reactions, short replies. Visible to the actor on `/me/activity`; not shown to others on Sifa. |
+| `filtered` | (none) | no | Infrastructure, configuration, moderation (blocks/mutes/flags), ephemeral consumption signals (bookmarks, highlights), game state, OAuth scope records. Not shown anywhere in Sifa. |
+
+Records in `action` and `filtered` still exist on the author's PDS and may be
+displayed by other apps. Sifa simply opts out of rendering them on its own
+surfaces.
+
+## Schema
+
+```json
+{
+  "$schema": "https://sifa.id/schemas/activity-tiers/v1.json",
+  "version": "1.0.0",
+  "updated": "YYYY-MM-DD",
+  "tiers": {
+    "<tier-id>": {
+      "label": "<short label or null>",
+      "description": "<one-sentence description>",
+      "shownOnPublicProfile": true | false
+    }
+  },
+  "lexicons": {
+    "<nsid>": {
+      "tier": "creation" | "action" | "filtered",
+      "app": "<optional app id>",
+      "notes": "<optional caveat>"
+    }
+  }
+}
+```
+
+`app` values correspond to ids in `sifa-api`'s `atproto-app-registry.ts` plus
+the sibling products: `sifa`, `barazo`. The field is informational; consumers
+should switch on `tier`, not `app`.
+
+## How to consume it
+
+Sifa serves this file at `https://sifa.id/.well-known/activity-tiers.json`
+(deployment path TBD — see "Deployment" below). Recommended consumers:
+
+```ts
+const res = await fetch('https://sifa.id/.well-known/activity-tiers.json');
+const spec = await res.json();
+const tier = spec.lexicons[nsid]?.tier ?? 'filtered';
+```
+
+Suggested defaults for NSIDs not listed in the file:
+- If the NSID's parent app is registered in `sifa-api`'s registry and not in
+  `EXCLUDED_COLLECTIONS`, treat it as `creation`.
+- Otherwise treat it as `filtered`.
+
+A typed helper in `@singi-labs/sifa-sdk` is a planned follow-up; until then,
+consumers can copy the JSON or fetch it at build time.
+
+## Proposing changes
+
+Open a pull request against `well-known/activity-tiers.json` in
+[`singi-labs/sifa-lexicons`](https://github.com/singi-labs/sifa-lexicons). PRs
+should:
+
+1. State which NSID(s) are being added/reclassified.
+2. Link evidence (lexicon definition, app docs, registry entry).
+3. Bump `version` per the versioning policy below.
+4. Bump `updated`.
+
+Reclassifying an existing NSID across tiers (e.g. `action` to `creation`) is a
+breaking change for consumers and must go through a major bump.
+
+## Versioning
+
+The `version` field follows semver:
+
+| Change | Bump |
+|--------|------|
+| Tier renamed, tier removed, NSID moved between tiers | major |
+| New NSID added, new tier added | minor |
+| Note/typo fix, `app` field change, `updated` field touch | patch |
+
+The current version is `1.0.0`. The `$schema` URL is reserved for a future
+JSON Schema description and may 404 until then.
+
+## Limitations and honest caveats
+
+- This is Sifa's editorial classification. Other AT Protocol AppViews are free
+  to show, hide, or recombine the same records however they like.
+- Records on the author's PDS are public regardless of tier. `filtered` does
+  not mean private.
+- A handful of NSIDs are inherently ambiguous (e.g. `app.bsky.feed.post`
+  carries both throwaway social posts and serious long-form writing). The spec
+  picks one tier per NSID; per-record nuance is the consumer layer's job.
+- Coverage is bounded by what Sifa currently knows about. The file mirrors
+  `sifa-api`'s `atproto-app-registry.ts` plus the sibling products' lexicons
+  (`id.sifa.*`, `forum.barazo.*`). New AT Protocol apps appear all the time;
+  this list will lag and should be updated as Sifa adds support for them.
+
+## Deployment
+
+The source of truth is this file in `sifa-lexicons`. Serving it at
+`https://sifa.id/.well-known/activity-tiers.json` is a follow-up: `sifa-web`
+does not yet expose anything from `/.well-known/`. A follow-up PR in
+`sifa-web` will mirror this file (likely via `public/.well-known/` or a Next.js
+route handler) so the URL above resolves.
+
+Until then, consumers should treat the GitHub raw URL as the canonical source:
+
+```
+https://raw.githubusercontent.com/singi-labs/sifa-lexicons/main/well-known/activity-tiers.json
+```
+
+## Rationale
+
+Sifa's "show your work" trust model means surfaces have to decide, per record
+type, whether a given activity is the kind of thing that belongs on a
+professional profile. Without a shared classification, every consumer (Sifa
+profile page, Sifa timeline, owner-Stream, third-party AppViews) reinvents the
+same decisions inconsistently. This spec centralises the editorial call so
+those surfaces stay coherent as new ATproto apps appear.

--- a/well-known/activity-tiers.json
+++ b/well-known/activity-tiers.json
@@ -27,37 +27,81 @@
     },
     "app.bsky.feed.like": { "tier": "action", "app": "bluesky" },
     "app.bsky.feed.repost": { "tier": "action", "app": "bluesky" },
-    "app.bsky.feed.generator": { "tier": "filtered", "app": "bluesky", "notes": "Feed generator definition record, not personal activity." },
+    "app.bsky.feed.generator": {
+      "tier": "filtered",
+      "app": "bluesky",
+      "notes": "Feed generator definition record, not personal activity."
+    },
     "app.bsky.graph.follow": { "tier": "action", "app": "bluesky" },
     "app.bsky.graph.block": { "tier": "filtered", "app": "bluesky", "notes": "Moderation record." },
     "app.bsky.graph.mute": { "tier": "filtered", "app": "bluesky", "notes": "Moderation record." },
-    "app.bsky.graph.listblock": { "tier": "filtered", "app": "bluesky", "notes": "Moderation record." },
-    "app.bsky.graph.listitem": { "tier": "filtered", "app": "bluesky", "notes": "List membership; rendered via the parent list, not as standalone activity." },
-    "app.bsky.graph.list": { "tier": "filtered", "app": "bluesky", "notes": "User-curated list metadata; not surfaced as profile activity." },
+    "app.bsky.graph.listblock": {
+      "tier": "filtered",
+      "app": "bluesky",
+      "notes": "Moderation record."
+    },
+    "app.bsky.graph.listitem": {
+      "tier": "filtered",
+      "app": "bluesky",
+      "notes": "List membership; rendered via the parent list, not as standalone activity."
+    },
+    "app.bsky.graph.list": {
+      "tier": "filtered",
+      "app": "bluesky",
+      "notes": "User-curated list metadata; not surfaced as profile activity."
+    },
     "app.bsky.graph.starterpack": { "tier": "filtered", "app": "bluesky" },
-    "app.bsky.actor.profile": { "tier": "filtered", "app": "bluesky", "notes": "Profile metadata record." },
+    "app.bsky.actor.profile": {
+      "tier": "filtered",
+      "app": "bluesky",
+      "notes": "Profile metadata record."
+    },
 
     "sh.tangled.repo": { "tier": "creation", "app": "tangled" },
     "sh.tangled.repo.issue": { "tier": "creation", "app": "tangled" },
     "sh.tangled.repo.pull": { "tier": "creation", "app": "tangled" },
     "sh.tangled.feed.star": { "tier": "action", "app": "tangled" },
     "sh.tangled.graph.follow": { "tier": "action", "app": "tangled" },
-    "sh.tangled.actor.profile": { "tier": "filtered", "app": "tangled", "notes": "Profile metadata record." },
+    "sh.tangled.actor.profile": {
+      "tier": "filtered",
+      "app": "tangled",
+      "notes": "Profile metadata record."
+    },
 
     "community.lexicon.calendar.rsvp": {
       "tier": "creation",
       "app": "smokesignal",
       "notes": "Ambiguous: RSVPs are reactions to events, but they are public commitments and the only Smoke Signal record Sifa scans today. Classified as creation."
     },
-    "events.smokesignal.profile": { "tier": "filtered", "app": "smokesignal", "notes": "Profile metadata record." },
+    "events.smokesignal.profile": {
+      "tier": "filtered",
+      "app": "smokesignal",
+      "notes": "Profile metadata record."
+    },
 
     "blue.flashes.feed.post": { "tier": "creation", "app": "flashes" },
 
     "social.grain.gallery": { "tier": "creation", "app": "grain" },
-    "social.grain.gallery.item": { "tier": "filtered", "app": "grain", "notes": "Item-within-gallery; rendered via parent gallery." },
-    "social.grain.photo": { "tier": "filtered", "app": "grain", "notes": "Raw photo asset; surfaced via the gallery that references it." },
-    "social.grain.photo.exif": { "tier": "filtered", "app": "grain", "notes": "EXIF metadata for a photo." },
-    "social.grain.story": { "tier": "filtered", "app": "grain", "notes": "Ephemeral story format." },
+    "social.grain.gallery.item": {
+      "tier": "filtered",
+      "app": "grain",
+      "notes": "Item-within-gallery; rendered via parent gallery."
+    },
+    "social.grain.photo": {
+      "tier": "filtered",
+      "app": "grain",
+      "notes": "Raw photo asset; surfaced via the gallery that references it."
+    },
+    "social.grain.photo.exif": {
+      "tier": "filtered",
+      "app": "grain",
+      "notes": "EXIF metadata for a photo."
+    },
+    "social.grain.story": {
+      "tier": "filtered",
+      "app": "grain",
+      "notes": "Ephemeral story format."
+    },
 
     "com.whtwnd.blog.entry": { "tier": "creation", "app": "whitewind" },
 
@@ -80,15 +124,43 @@
     "social.popfeed.feed.post": { "tier": "creation", "app": "popfeed" },
     "social.popfeed.feed.note": { "tier": "creation", "app": "popfeed" },
     "social.popfeed.feed.like": { "tier": "action", "app": "popfeed" },
-    "social.popfeed.challenge.participation": { "tier": "filtered", "app": "popfeed", "notes": "Challenge participation tracking." },
-    "social.popfeed.actor.profile": { "tier": "filtered", "app": "popfeed", "notes": "Profile metadata record." },
+    "social.popfeed.challenge.participation": {
+      "tier": "filtered",
+      "app": "popfeed",
+      "notes": "Challenge participation tracking."
+    },
+    "social.popfeed.actor.profile": {
+      "tier": "filtered",
+      "app": "popfeed",
+      "notes": "Profile metadata record."
+    },
 
     "place.stream.livestream": { "tier": "creation", "app": "streamplace" },
-    "place.stream.broadcast.origin": { "tier": "filtered", "app": "streamplace", "notes": "Broadcast origin/infrastructure record." },
-    "place.stream.key": { "tier": "filtered", "app": "streamplace", "notes": "Stream key — sensitive infrastructure record." },
-    "place.stream.metadata.configuration": { "tier": "filtered", "app": "streamplace", "notes": "Stream configuration metadata." },
-    "place.stream.chat.message": { "tier": "filtered", "app": "streamplace", "notes": "Ephemeral chat message." },
-    "place.stream.chat.profile": { "tier": "filtered", "app": "streamplace", "notes": "Chat profile metadata." },
+    "place.stream.broadcast.origin": {
+      "tier": "filtered",
+      "app": "streamplace",
+      "notes": "Broadcast origin/infrastructure record."
+    },
+    "place.stream.key": {
+      "tier": "filtered",
+      "app": "streamplace",
+      "notes": "Stream key — sensitive infrastructure record."
+    },
+    "place.stream.metadata.configuration": {
+      "tier": "filtered",
+      "app": "streamplace",
+      "notes": "Stream configuration metadata."
+    },
+    "place.stream.chat.message": {
+      "tier": "filtered",
+      "app": "streamplace",
+      "notes": "Ephemeral chat message."
+    },
+    "place.stream.chat.profile": {
+      "tier": "filtered",
+      "app": "streamplace",
+      "notes": "Chat profile metadata."
+    },
 
     "app.sidetrail.trail": { "tier": "creation", "app": "semble" },
     "app.sidetrail.walk": { "tier": "creation", "app": "semble" },
@@ -97,18 +169,54 @@
 
     "pub.leaflet.comment": { "tier": "creation", "app": "leaflet" },
     "pub.leaflet.interactions.recommend": { "tier": "action", "app": "leaflet" },
-    "pub.leaflet.authFullPermissions": { "tier": "filtered", "app": "leaflet", "notes": "OAuth permission record." },
+    "pub.leaflet.authFullPermissions": {
+      "tier": "filtered",
+      "app": "leaflet",
+      "notes": "OAuth permission record."
+    },
 
     "social.colibri.membership": { "tier": "creation", "app": "colibri" },
-    "social.colibri.message": { "tier": "filtered", "app": "colibri", "notes": "Chat message — high-volume conversational signal, not portfolio." },
+    "social.colibri.message": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Chat message — high-volume conversational signal, not portfolio."
+    },
     "social.colibri.reaction": { "tier": "filtered", "app": "colibri", "notes": "Chat reaction." },
-    "social.colibri.channel": { "tier": "filtered", "app": "colibri", "notes": "Channel definition." },
-    "social.colibri.community": { "tier": "filtered", "app": "colibri", "notes": "Community definition." },
-    "social.colibri.approval": { "tier": "filtered", "app": "colibri", "notes": "Moderation approval record." },
-    "social.colibri.category": { "tier": "filtered", "app": "colibri", "notes": "Category metadata." },
-    "social.colibri.channel.read": { "tier": "filtered", "app": "colibri", "notes": "Read-state marker." },
-    "social.colibri.actor.data": { "tier": "filtered", "app": "colibri", "notes": "Actor metadata." },
-    "social.colibri.richtext.facet": { "tier": "filtered", "app": "colibri", "notes": "Richtext facet sub-record." },
+    "social.colibri.channel": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Channel definition."
+    },
+    "social.colibri.community": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Community definition."
+    },
+    "social.colibri.approval": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Moderation approval record."
+    },
+    "social.colibri.category": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Category metadata."
+    },
+    "social.colibri.channel.read": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Read-state marker."
+    },
+    "social.colibri.actor.data": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Actor metadata."
+    },
+    "social.colibri.richtext.facet": {
+      "tier": "filtered",
+      "app": "colibri",
+      "notes": "Richtext facet sub-record."
+    },
 
     "app.collectivesocial.feed.list": {
       "tier": "creation",
@@ -116,18 +224,37 @@
       "notes": "Auto-created default Inbox lists are filtered at the consumer layer via isDefault=true predicate."
     },
 
-    "net.alternativeproto.vote": { "tier": "action", "notes": "Vote record on a third-party protocol." },
-    "network.cosmik.collection": { "tier": "filtered", "notes": "Stale registry id — Cosmik formerly in app registry." },
+    "net.alternativeproto.vote": {
+      "tier": "action",
+      "notes": "Vote record on a third-party protocol."
+    },
+    "network.cosmik.collection": {
+      "tier": "filtered",
+      "notes": "Stale registry id — Cosmik formerly in app registry."
+    },
     "network.cosmik.collectionLink": { "tier": "filtered" },
     "network.cosmik.connection": { "tier": "filtered" },
     "network.cosmik.follow": { "tier": "filtered" },
     "network.cosmik.card": { "tier": "filtered", "notes": "Link-in-bio card; consumption signal." },
 
-    "social.pinksky.app.preference": { "tier": "filtered", "app": "bluesky", "notes": "Pinkleap (Bluesky client) app preferences." },
+    "social.pinksky.app.preference": {
+      "tier": "filtered",
+      "app": "bluesky",
+      "notes": "Pinkleap (Bluesky client) app preferences."
+    },
 
-    "at.margin.bookmark": { "tier": "filtered", "notes": "Bookmark — consumption signal, not creation." },
-    "at.margin.highlight": { "tier": "filtered", "notes": "Highlight — consumption signal, not creation." },
-    "community.lexicon.bookmarks.bookmark": { "tier": "filtered", "notes": "Bookmark — consumption signal." },
+    "at.margin.bookmark": {
+      "tier": "filtered",
+      "notes": "Bookmark — consumption signal, not creation."
+    },
+    "at.margin.highlight": {
+      "tier": "filtered",
+      "notes": "Highlight — consumption signal, not creation."
+    },
+    "community.lexicon.bookmarks.bookmark": {
+      "tier": "filtered",
+      "notes": "Bookmark — consumption signal."
+    },
     "blue.linkat.board": { "tier": "filtered", "notes": "Link-in-bio board; consumption signal." },
 
     "dev.skyboard.board": { "tier": "filtered", "notes": "Skyboard task-board metadata." },
@@ -135,9 +262,16 @@
     "dev.skyboard.task": { "tier": "filtered", "notes": "Skyboard task record." },
 
     "net.anisota.player.state": { "tier": "filtered", "notes": "Anisota game player state." },
-    "xyz.statusphere.status": { "tier": "filtered", "notes": "Statusphere emoji status — leisure signal." },
+    "xyz.statusphere.status": {
+      "tier": "filtered",
+      "notes": "Statusphere emoji status — leisure signal."
+    },
 
-    "id.sifa.profile.self": { "tier": "creation", "app": "sifa", "notes": "Sifa professional profile root." },
+    "id.sifa.profile.self": {
+      "tier": "creation",
+      "app": "sifa",
+      "notes": "Sifa professional profile root."
+    },
     "id.sifa.profile.position": { "tier": "creation", "app": "sifa" },
     "id.sifa.profile.education": { "tier": "creation", "app": "sifa" },
     "id.sifa.profile.skill": { "tier": "creation", "app": "sifa" },
@@ -150,16 +284,32 @@
     "id.sifa.profile.language": { "tier": "creation", "app": "sifa" },
     "id.sifa.profile.externalAccount": { "tier": "creation", "app": "sifa" },
     "id.sifa.profile.location": { "tier": "creation", "app": "sifa" },
-    "id.sifa.endorsement": { "tier": "creation", "app": "sifa", "notes": "Endorsement authored by the actor about another profile." },
-    "id.sifa.endorsement.confirmation": { "tier": "action", "app": "sifa", "notes": "Confirmation/acceptance of an endorsement received." },
+    "id.sifa.endorsement": {
+      "tier": "creation",
+      "app": "sifa",
+      "notes": "Endorsement authored by the actor about another profile."
+    },
+    "id.sifa.endorsement.confirmation": {
+      "tier": "action",
+      "app": "sifa",
+      "notes": "Confirmation/acceptance of an endorsement received."
+    },
     "id.sifa.graph.follow": { "tier": "action", "app": "sifa" },
-    "id.sifa.graph.connection": { "tier": "creation", "app": "sifa", "notes": "Mutual professional connection record." },
+    "id.sifa.graph.connection": {
+      "tier": "creation",
+      "app": "sifa",
+      "notes": "Mutual professional connection record."
+    },
     "id.sifa.project.self": { "tier": "creation", "app": "sifa" },
     "id.sifa.project.member": { "tier": "creation", "app": "sifa" },
     "id.sifa.project.membership": { "tier": "creation", "app": "sifa" },
     "id.sifa.meeting": { "tier": "creation", "app": "sifa" },
     "id.sifa.authProfile": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
-    "id.sifa.authProfileAccess": { "tier": "filtered", "app": "sifa", "notes": "OAuth profile-access record." },
+    "id.sifa.authProfileAccess": {
+      "tier": "filtered",
+      "app": "sifa",
+      "notes": "OAuth profile-access record."
+    },
     "id.sifa.authProject": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
     "id.sifa.authConnection": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
     "id.sifa.authMeet": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
@@ -168,7 +318,11 @@
     "forum.barazo.community.member": { "tier": "creation", "app": "barazo" },
     "forum.barazo.reputation.event": { "tier": "creation", "app": "barazo" },
     "forum.barazo.reaction": { "tier": "action", "app": "barazo" },
-    "forum.barazo.reply": { "tier": "action", "app": "barazo", "notes": "Short conversational reply — engagement signal." },
+    "forum.barazo.reply": {
+      "tier": "action",
+      "app": "barazo",
+      "notes": "Short conversational reply — engagement signal."
+    },
     "forum.barazo.flag": { "tier": "filtered", "app": "barazo", "notes": "Moderation flag." }
   }
 }

--- a/well-known/activity-tiers.json
+++ b/well-known/activity-tiers.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://sifa.id/schemas/activity-tiers/v1.json",
+  "version": "1.0.0",
+  "updated": "2026-05-28",
+  "tiers": {
+    "creation": {
+      "label": "Made",
+      "description": "Substantive records the actor authored: posts, articles, repos, galleries, livestreams, RSVPs, CV entries. Surfaced on the public profile and in the network timeline.",
+      "shownOnPublicProfile": true
+    },
+    "action": {
+      "label": "Did",
+      "description": "Engagement records (likes, reposts, follows, votes, stars, reactions). Visible to the actor on the 'What is public about me' page and on the originating app, but not surfaced on the Sifa public profile.",
+      "shownOnPublicProfile": false
+    },
+    "filtered": {
+      "label": null,
+      "description": "Configuration, infrastructure, moderation, game state, ephemeral consumption signals (bookmarks, highlights), and other records Sifa does not display anywhere. The records remain public on the actor's PDS regardless.",
+      "shownOnPublicProfile": false
+    }
+  },
+  "lexicons": {
+    "app.bsky.feed.post": {
+      "tier": "creation",
+      "app": "bluesky",
+      "notes": "Ambiguous: many posts are casual, but the lexicon also carries long-form posts and threads. Treated as creation; empty quote-posts (no text + record embed) are filtered at the consumer layer, not here."
+    },
+    "app.bsky.feed.like": { "tier": "action", "app": "bluesky" },
+    "app.bsky.feed.repost": { "tier": "action", "app": "bluesky" },
+    "app.bsky.feed.generator": { "tier": "filtered", "app": "bluesky", "notes": "Feed generator definition record, not personal activity." },
+    "app.bsky.graph.follow": { "tier": "action", "app": "bluesky" },
+    "app.bsky.graph.block": { "tier": "filtered", "app": "bluesky", "notes": "Moderation record." },
+    "app.bsky.graph.mute": { "tier": "filtered", "app": "bluesky", "notes": "Moderation record." },
+    "app.bsky.graph.listblock": { "tier": "filtered", "app": "bluesky", "notes": "Moderation record." },
+    "app.bsky.graph.listitem": { "tier": "filtered", "app": "bluesky", "notes": "List membership; rendered via the parent list, not as standalone activity." },
+    "app.bsky.graph.list": { "tier": "filtered", "app": "bluesky", "notes": "User-curated list metadata; not surfaced as profile activity." },
+    "app.bsky.graph.starterpack": { "tier": "filtered", "app": "bluesky" },
+    "app.bsky.actor.profile": { "tier": "filtered", "app": "bluesky", "notes": "Profile metadata record." },
+
+    "sh.tangled.repo": { "tier": "creation", "app": "tangled" },
+    "sh.tangled.repo.issue": { "tier": "creation", "app": "tangled" },
+    "sh.tangled.repo.pull": { "tier": "creation", "app": "tangled" },
+    "sh.tangled.feed.star": { "tier": "action", "app": "tangled" },
+    "sh.tangled.graph.follow": { "tier": "action", "app": "tangled" },
+    "sh.tangled.actor.profile": { "tier": "filtered", "app": "tangled", "notes": "Profile metadata record." },
+
+    "community.lexicon.calendar.rsvp": {
+      "tier": "creation",
+      "app": "smokesignal",
+      "notes": "Ambiguous: RSVPs are reactions to events, but they are public commitments and the only Smoke Signal record Sifa scans today. Classified as creation."
+    },
+    "events.smokesignal.profile": { "tier": "filtered", "app": "smokesignal", "notes": "Profile metadata record." },
+
+    "blue.flashes.feed.post": { "tier": "creation", "app": "flashes" },
+
+    "social.grain.gallery": { "tier": "creation", "app": "grain" },
+    "social.grain.gallery.item": { "tier": "filtered", "app": "grain", "notes": "Item-within-gallery; rendered via parent gallery." },
+    "social.grain.photo": { "tier": "filtered", "app": "grain", "notes": "Raw photo asset; surfaced via the gallery that references it." },
+    "social.grain.photo.exif": { "tier": "filtered", "app": "grain", "notes": "EXIF metadata for a photo." },
+    "social.grain.story": { "tier": "filtered", "app": "grain", "notes": "Ephemeral story format." },
+
+    "com.whtwnd.blog.entry": { "tier": "creation", "app": "whitewind" },
+
+    "fyi.unravel.frontpage.post": { "tier": "creation", "app": "frontpage" },
+    "fyi.unravel.frontpage.vote": { "tier": "action", "app": "frontpage" },
+
+    "social.psky.feed.post": { "tier": "creation", "app": "picosky" },
+
+    "link.pastesphere.snippet": { "tier": "creation", "app": "pastesphere" },
+
+    "site.standard.document": { "tier": "creation", "app": "standard" },
+
+    "computer.aetheros.page": { "tier": "creation", "app": "aetheros" },
+
+    "space.roomy.space.personal": { "tier": "creation", "app": "roomy" },
+
+    "dev.keytrace.claim": { "tier": "creation", "app": "keytrace" },
+
+    "social.popfeed.feed.review": { "tier": "creation", "app": "popfeed" },
+    "social.popfeed.feed.post": { "tier": "creation", "app": "popfeed" },
+    "social.popfeed.feed.note": { "tier": "creation", "app": "popfeed" },
+    "social.popfeed.feed.like": { "tier": "action", "app": "popfeed" },
+    "social.popfeed.challenge.participation": { "tier": "filtered", "app": "popfeed", "notes": "Challenge participation tracking." },
+    "social.popfeed.actor.profile": { "tier": "filtered", "app": "popfeed", "notes": "Profile metadata record." },
+
+    "place.stream.livestream": { "tier": "creation", "app": "streamplace" },
+    "place.stream.broadcast.origin": { "tier": "filtered", "app": "streamplace", "notes": "Broadcast origin/infrastructure record." },
+    "place.stream.key": { "tier": "filtered", "app": "streamplace", "notes": "Stream key — sensitive infrastructure record." },
+    "place.stream.metadata.configuration": { "tier": "filtered", "app": "streamplace", "notes": "Stream configuration metadata." },
+    "place.stream.chat.message": { "tier": "filtered", "app": "streamplace", "notes": "Ephemeral chat message." },
+    "place.stream.chat.profile": { "tier": "filtered", "app": "streamplace", "notes": "Chat profile metadata." },
+
+    "app.sidetrail.trail": { "tier": "creation", "app": "semble" },
+    "app.sidetrail.walk": { "tier": "creation", "app": "semble" },
+
+    "at.youandme.connection": { "tier": "creation", "app": "youandme" },
+
+    "pub.leaflet.comment": { "tier": "creation", "app": "leaflet" },
+    "pub.leaflet.interactions.recommend": { "tier": "action", "app": "leaflet" },
+    "pub.leaflet.authFullPermissions": { "tier": "filtered", "app": "leaflet", "notes": "OAuth permission record." },
+
+    "social.colibri.membership": { "tier": "creation", "app": "colibri" },
+    "social.colibri.message": { "tier": "filtered", "app": "colibri", "notes": "Chat message — high-volume conversational signal, not portfolio." },
+    "social.colibri.reaction": { "tier": "filtered", "app": "colibri", "notes": "Chat reaction." },
+    "social.colibri.channel": { "tier": "filtered", "app": "colibri", "notes": "Channel definition." },
+    "social.colibri.community": { "tier": "filtered", "app": "colibri", "notes": "Community definition." },
+    "social.colibri.approval": { "tier": "filtered", "app": "colibri", "notes": "Moderation approval record." },
+    "social.colibri.category": { "tier": "filtered", "app": "colibri", "notes": "Category metadata." },
+    "social.colibri.channel.read": { "tier": "filtered", "app": "colibri", "notes": "Read-state marker." },
+    "social.colibri.actor.data": { "tier": "filtered", "app": "colibri", "notes": "Actor metadata." },
+    "social.colibri.richtext.facet": { "tier": "filtered", "app": "colibri", "notes": "Richtext facet sub-record." },
+
+    "app.collectivesocial.feed.list": {
+      "tier": "creation",
+      "app": "collectivesocial",
+      "notes": "Auto-created default Inbox lists are filtered at the consumer layer via isDefault=true predicate."
+    },
+
+    "net.alternativeproto.vote": { "tier": "action", "notes": "Vote record on a third-party protocol." },
+    "network.cosmik.collection": { "tier": "filtered", "notes": "Stale registry id — Cosmik formerly in app registry." },
+    "network.cosmik.collectionLink": { "tier": "filtered" },
+    "network.cosmik.connection": { "tier": "filtered" },
+    "network.cosmik.follow": { "tier": "filtered" },
+    "network.cosmik.card": { "tier": "filtered", "notes": "Link-in-bio card; consumption signal." },
+
+    "social.pinksky.app.preference": { "tier": "filtered", "app": "bluesky", "notes": "Pinkleap (Bluesky client) app preferences." },
+
+    "at.margin.bookmark": { "tier": "filtered", "notes": "Bookmark — consumption signal, not creation." },
+    "at.margin.highlight": { "tier": "filtered", "notes": "Highlight — consumption signal, not creation." },
+    "community.lexicon.bookmarks.bookmark": { "tier": "filtered", "notes": "Bookmark — consumption signal." },
+    "blue.linkat.board": { "tier": "filtered", "notes": "Link-in-bio board; consumption signal." },
+
+    "dev.skyboard.board": { "tier": "filtered", "notes": "Skyboard task-board metadata." },
+    "dev.skyboard.op": { "tier": "filtered", "notes": "Skyboard operation log." },
+    "dev.skyboard.task": { "tier": "filtered", "notes": "Skyboard task record." },
+
+    "net.anisota.player.state": { "tier": "filtered", "notes": "Anisota game player state." },
+    "xyz.statusphere.status": { "tier": "filtered", "notes": "Statusphere emoji status — leisure signal." },
+
+    "id.sifa.profile.self": { "tier": "creation", "app": "sifa", "notes": "Sifa professional profile root." },
+    "id.sifa.profile.position": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.education": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.skill": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.certification": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.project": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.volunteering": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.publication": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.course": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.honor": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.language": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.externalAccount": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.location": { "tier": "creation", "app": "sifa" },
+    "id.sifa.endorsement": { "tier": "creation", "app": "sifa", "notes": "Endorsement authored by the actor about another profile." },
+    "id.sifa.endorsement.confirmation": { "tier": "action", "app": "sifa", "notes": "Confirmation/acceptance of an endorsement received." },
+    "id.sifa.graph.follow": { "tier": "action", "app": "sifa" },
+    "id.sifa.graph.connection": { "tier": "creation", "app": "sifa", "notes": "Mutual professional connection record." },
+    "id.sifa.project.self": { "tier": "creation", "app": "sifa" },
+    "id.sifa.project.member": { "tier": "creation", "app": "sifa" },
+    "id.sifa.project.membership": { "tier": "creation", "app": "sifa" },
+    "id.sifa.meeting": { "tier": "creation", "app": "sifa" },
+    "id.sifa.authProfile": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
+    "id.sifa.authProfileAccess": { "tier": "filtered", "app": "sifa", "notes": "OAuth profile-access record." },
+    "id.sifa.authProject": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
+    "id.sifa.authConnection": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
+    "id.sifa.authMeet": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
+
+    "forum.barazo.post": { "tier": "creation", "app": "barazo" },
+    "forum.barazo.community.member": { "tier": "creation", "app": "barazo" },
+    "forum.barazo.reputation.event": { "tier": "creation", "app": "barazo" },
+    "forum.barazo.reaction": { "tier": "action", "app": "barazo" },
+    "forum.barazo.reply": { "tier": "action", "app": "barazo", "notes": "Short conversational reply — engagement signal." },
+    "forum.barazo.flag": { "tier": "filtered", "app": "barazo", "notes": "Moderation flag." }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `well-known/activity-tiers.json` and a companion `README.md` — Sifa's canonical mapping of AT Protocol record types (NSIDs) to display tiers:

- **creation** ("Made") — substantive authored records, shown on public profile
- **action** ("Did") — engagement records, owner-only on the activity page
- **filtered** — infra, config, moderation, ephemeral consumption signals; hidden everywhere in Sifa

112 NSIDs classified: 47 creation / 13 action / 52 filtered. Includes every NSID from `sifa-api`'s `atproto-app-registry.ts` (both `scanCollections` and `EXCLUDED_COLLECTIONS`), all `id.sifa.*` lexicons in this repo, and the `forum.barazo.*` records Sifa renders.

## Why now

Follows the activity-display review synthesis: surfaces have to decide per-record-type whether something belongs on a professional profile, and without a shared classification every consumer (profile page, network timeline, owner-Stream, third-party AppViews) reinvents the same decisions inconsistently. This centralises the editorial call.

Pairs with sifa-web#1052 (the public-facing 'What is public about me?' disclosure on `/settings/activity`), which is the first surface that will consume this taxonomy.

## What consumes it next

- `/me/activity` (owner-Stream) — render action-tier records to the owner only
- The 'What is public about you' page — explain the tiering to users
- A typed helper in `@singi-labs/sifa-sdk` (separate follow-up PR)
- A `sifa-web` PR to mirror the JSON into `/public/.well-known/` so `https://sifa.id/.well-known/activity-tiers.json` resolves (deployment path TBD; see README)

## Ambiguities punted

- `app.bsky.feed.post` — classed as creation; per-record nuance (e.g. empty quote-posts) stays at the consumer layer where existing `shouldIncludeRecord` filters already live.
- `community.lexicon.calendar.rsvp` — RSVPs straddle action vs. creation. Classed as creation because it's a public commitment and the only Smoke Signal record Sifa scans today.
- `id.sifa.graph.connection` — classed as creation (mutual prof. relationship), while `id.sifa.graph.follow` is action.

## Out of scope

- No consumer code changes (no edits to sifa-api, sifa-web, sifa-sdk)
- No runtime helper / SDK export — separate follow-up
- Inventing NSIDs not in the registry (a few candidates worth a future pass: `app.bsky.feed.threadgate`, `app.bsky.feed.postgate`, Bluesky's labeler/verification records)

## Test plan

- [x] JSON parses; total NSID count and tier breakdown verified (`47 / 13 / 52`)
- [x] Every NSID in `sifa-api` `scanCollections` and `EXCLUDED_COLLECTIONS` is present
- [x] Every `id.sifa.*` lexicon in this repo is classified
- [x] `forum.barazo.*` core records (post/community.member/reputation.event/reaction/reply/flag) classified per spec brief
- [ ] Reviewer sanity-check on ambiguous calls (post, rsvp, connection vs. follow)