### PR TITLE
chore: bump Node to 26 (major)

### DIFF
--- a/.github/workflows/publish-lexicons.yml
+++ b/.github/workflows/publish-lexicons.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 26.16
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/publish-lexicons.yml
+++ b/.github/workflows/publish-lexicons.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 26.16
+          node-version: 26
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 26.16
+          node-version: 26
           cache: npm
           registry-url: https://npm.pkg.github.com
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 26.16
           cache: npm
           registry-url: https://npm.pkg.github.com
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 26.16
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 26.16
+          node-version: 26
           cache: npm
 
       - run: npm ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ AT Protocol lexicon schemas for Sifa -- a decentralized professional identity an
 
 | Component  | Technology                       |
 | ---------- | -------------------------------- |
-| Runtime    | Node.js 25 / TypeScript (strict) |
+| Runtime    | Node.js 26 / TypeScript (strict) |
 | Schemas    | AT Protocol Lexicon JSON         |
 | Code gen   | @atproto/lex-cli                 |
 | Validation | Zod (generated from lexicons)    |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ These lexicons reference types from:
 
 ## Quick Start
 
-**Prerequisites:** Node.js 25+, npm.
+**Prerequisites:** Node.js 26+, npm.
 
 ```bash
 git clone https://github.com/singi-labs/sifa-lexicons.git


### PR DESCRIPTION
## Summary
- node-version 25 → 26 in validate, publish, publish-lexicons workflows (major-only; Node 26.16 doesn't exist)
- README + AGENTS: Node.js 25 → 26

## Why
Node 25 EOL today (2026-06-01). Node 26 becomes Active LTS 2026-10-28. Adopting ahead of LTS — Sifa still alpha.

## Test plan
- [ ] Validate workflow passes