### PR TITLE
docs(graph): document follow as distinct graph and prepare ecosystem review

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Every schema in this repo is published as a `com.atproto.lexicon.schema` record 
 | `id.sifa.graph.follow`     | Professional follows            |
 | `id.sifa.graph.connection` | Mutual professional connections |
 
+> **`id.sifa.graph.follow` is a distinct graph, not a Bluesky superset.**
+> Sifa's follow graph captures the intent "I want to see this person's professional
+> content on Sifa." It is **not** a superset, mirror, or extension of
+> `app.bsky.graph.follow`. A Bluesky-only client must not assume the two are
+> interchangeable: following on Bluesky does not imply a Sifa follow, and vice
+> versa. Each graph is owned by its own AppView contract. Users who want both
+> relationships create both records.
+
 **Collaborative projects**
 
 | NSID                         | Purpose                                 |

--- a/docs/ecosystem-review-thread.md
+++ b/docs/ecosystem-review-thread.md
@@ -1,0 +1,111 @@
+# Ecosystem review: `id.sifa.graph.follow`
+
+Draft text for the public review thread. Paste into the atproto Discord (Guido
+will post manually) and open a parallel issue on
+[`lexicon-community/lexicon`](https://github.com/lexicon-community/lexicon)
+proposing promotion to `community.lexicon.graph.follow`.
+
+Do **not** post automatically from CI or from this repo. The point of the
+review window is human judgement.
+
+---
+
+## Subject
+
+Review request: `id.sifa.graph.follow` — a professional-context follow graph (and possible `community.lexicon.graph.follow` candidate)
+
+## Body
+
+Hi all,
+
+Sifa (the AT Protocol professional-network AppView at [sifa.id](https://sifa.id))
+is about to start emitting follow records to the firehose. Before we do, we want
+ecosystem eyes on the lexicon and the semantics.
+
+### The lexicon
+
+NSID: `id.sifa.graph.follow`
+Schema: <https://github.com/singi-labs/sifa-lexicons/blob/main/lexicons/id/sifa/graph/follow.json>
+Resolvable at: `did:plc:2f2ahswozqy4v5lvu676375y` (verified via `_lexicon.sifa.id` TXT record)
+
+```json
+{
+  "lexicon": 1,
+  "id": "id.sifa.graph.follow",
+  "description": "A one-way professional follow. Indicates the follower wants to see the subject's professional content on Sifa.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": { "type": "string", "format": "did" },
+          "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}
+```
+
+The shape is intentionally minimal and matches the conventions used by
+`app.bsky.graph.follow`: a single `subject` DID, a `createdAt` datetime, TID key.
+
+### Semantic distinction (important)
+
+`id.sifa.graph.follow` is **a distinct graph, not a Bluesky superset.**
+
+- It captures the intent "I want to see this person's _professional_ content on
+  Sifa," not their general social posts.
+- It is **not** a superset, mirror, or extension of `app.bsky.graph.follow`.
+- A Bluesky-only client must not assume the two are interchangeable. Following
+  someone on Bluesky does not imply a Sifa follow, and vice versa. Each graph
+  belongs to its own AppView contract.
+- Users who want both relationships create both records.
+
+We chose a separate NSID (instead of reusing `app.bsky.graph.follow`) precisely
+because the _audience_ and _consent_ model are different: Sifa surfaces
+professional activity (jobs, projects, endorsements, certifications). A user
+agreeing to follow someone professionally is a distinct act from agreeing to
+follow them socially.
+
+### What we're asking for
+
+1. **Sanity-check the schema.** Is there anything obviously wrong, missing, or
+   non-idiomatic? We deliberately omitted optional metadata (no `note`, no
+   `visibility`, no labels) — keeping iter-1 minimal. Happy to defend or
+   reconsider that choice.
+2. **Naming feedback.** Does `id.sifa.graph.follow` read correctly to other
+   AppView authors? Any collision concerns?
+3. **Promotion candidate?** Would the lexicon-community find a generalized
+   `community.lexicon.graph.follow` useful — i.e. a generic "context-scoped
+   follow" type that any AppView could reuse? Sifa is willing to migrate if a
+   consensus shape forms. Otherwise we stay in the `id.sifa.*` namespace.
+4. **Firehose etiquette.** We plan to start emitting `id.sifa.graph.follow`
+   records to the relays no sooner than **two weeks** after this thread opens.
+   Flag any concerns about indexer load, NSID typo-squatting, or migration
+   timing now rather than after.
+
+### Out of scope for this round
+
+- Connection records (`id.sifa.graph.connection`, mutual + bidirectional) —
+  separate review later.
+- Adding optional fields. If review feedback demands a shape change, that's a
+  separate, explicit decision; we will not silently amend.
+- Sifa AppView ingest behavior (lives in `sifa-api`, not in this lexicon repo).
+
+Thanks for any time you can spend on this. Reply here, on the GitHub issue,
+or open a PR against the schema if you spot something concrete.
+
+— Guido (Singi Labs / Sifa)
+
+---
+
+## Tracking
+
+- Source issue: <https://github.com/singi-labs/sifa-lexicons/issues/54>
+- Epic: singi-labs/sifa-workspace#203
+- Review window: minimum 2 weeks between thread open and `sifa-api` starting
+  to emit follow records to the firehose.


### PR DESCRIPTION
## Summary

Iter-1 of the in-Sifa follow primitive epic (singi-labs/sifa-workspace#203), implementing the doc-only side of singi-labs/sifa-lexicons#54.

- README now states explicitly that `id.sifa.graph.follow` is a **distinct professional-context graph, not a superset or mirror of `app.bsky.graph.follow`** — Bluesky-only clients must not assume the two are interchangeable.
- New `docs/ecosystem-review-thread.md` contains the draft text Guido will paste into the atproto Discord and into a `lexicon-community/lexicon` promotion-proposal issue. Nothing in this PR posts automatically — the review window is intentionally human-driven.

**No changes to `lexicons/id/sifa/graph/follow.json`.** The shape (subject DID required, createdAt datetime required, key `tid`) was already correct.

## Acceptance criteria status (issue #54)

| AC | Status |
|----|--------|
| 1. npm package published at a frozen tag with current `follow.json` unchanged | Already satisfied: `@singi-labs/sifa-lexicons@0.6.2` already ships `lexicons/id/sifa/graph/follow.json` unchanged. No version bump needed. |
| 2. Public review thread URL linked in issue | Deferred to Guido (he posts to atproto Discord manually). Draft text in `docs/ecosystem-review-thread.md`. |
| 3. community-lexicon promotion proposal URL linked | Deferred to Guido (parallel issue on `lexicon-community/lexicon`). Same draft covers it. |
| 4. README states "distinct graph, not Bluesky-superset" semantic | Done. |
| 5. sifa-api ingest does NOT start until 2 weeks after thread open | Out of scope here (sifa-api repo). |
| 6. Breaking shape changes from review feedback = separate decision | Documented in the draft thread. |

## Why not "Closes #54"

ACs #2, #3, and #5 require human actions outside this repo (posting the thread, opening the community-lexicon issue, gating the firehose emit). Leaving the issue open so it can be closed once those URLs are linked in the issue body.

## Test plan

- [x] `npm run validate` — all lexicons regen cleanly, `src/generated/types/id/sifa/graph/follow.ts` exists.
- [x] `npm test` — 205/205 pass.
- [x] `npx prettier --check .` — clean.
- [x] CodeRabbit local pass — 1 trivial nit (wording), resolved.