### PR TITLE
feat(endorsement): add optional positionRef and credentialRef fields

### DIFF
--- a/lexicons/id/sifa/endorsement.json
+++ b/lexicons/id/sifa/endorsement.json
@@ -38,6 +38,16 @@
             "type": "string",
             "format": "datetime",
             "description": "Client-declared timestamp when this endorsement was created."
+          },
+          "positionRef": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Optional AT-URI of the id.sifa.position record this endorsement relates to. When present, indicates the endorsement is contextualised to a specific role rather than a general skill."
+          },
+          "credentialRef": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Optional AT-URI of an education or credential record this endorsement confirms. Mutually exclusive with positionRef in intent, though both are permitted."
           }
         }
       }

--- a/lexicons/id/sifa/endorsement.json
+++ b/lexicons/id/sifa/endorsement.json
@@ -40,14 +40,14 @@
             "description": "Client-declared timestamp when this endorsement was created."
           },
           "positionRef": {
-            "type": "string",
-            "format": "at-uri",
-            "description": "Optional AT-URI of the id.sifa.position record this endorsement relates to. When present, indicates the endorsement is contextualised to a specific role rather than a general skill."
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Optional reference to the id.sifa.position record this endorsement relates to. When present, indicates the endorsement is contextualised to a specific role rather than a general skill."
           },
           "credentialRef": {
-            "type": "string",
-            "format": "at-uri",
-            "description": "Optional AT-URI of an education or credential record this endorsement confirms. Mutually exclusive with positionRef in intent, though both are permitted."
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Optional reference to an education or credential record this endorsement confirms. May be set alongside positionRef when the endorsement relates to both a role and a credential."
           }
         }
       }


### PR DESCRIPTION
Adds two optional AT-URI reference fields to id.sifa.endorsement:
- positionRef: links an endorsement to a specific id.sifa.position record
- credentialRef: links an endorsement to an education/credential record

Both fields are optional and backward-compatible. No existing implementations are affected. Enables downstream apps to compute proximity-weighted trust signals from the endorsement graph.