### PR TITLE
feat(profile): make company optional on id.sifa.profile.position

### DIFF
--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -9,14 +9,14 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["company", "title", "startedAt", "createdAt"],
+        "required": ["title", "startedAt", "createdAt"],
         "properties": {
           "company": {
             "type": "string",
             "minLength": 1,
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Company or organization name."
+            "description": "Company or organization name. Optional: omit for self-employed, freelance, contract, or independent work that has no separately named or registered entity."
           },
           "companyDid": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -10,6 +10,7 @@ interface LexiconProperty {
   format?: string;
   maxGraphemes?: number;
   maxLength?: number;
+  minLength?: number;
   maxSize?: number;
   accept?: string[];
   description?: string;
@@ -263,7 +264,17 @@ describe('Position skills field', () => {
   });
 
   it('position without skills field is still valid (backward compatible)', () => {
-    expect(required).toEqual(['company', 'title', 'startedAt', 'createdAt']);
+    expect(required).toEqual(['title', 'startedAt', 'createdAt']);
+  });
+
+  it('company is no longer required (self-employed/freelance may omit it)', () => {
+    expect(required).not.toContain('company');
+  });
+
+  it('company remains a defined, non-empty string property when present', () => {
+    expect(properties?.company).toBeDefined();
+    expect(properties?.company?.type).toBe('string');
+    expect(properties?.company?.minLength).toBe(1);
   });
 });
 


### PR DESCRIPTION
## What

Drop `company` from the `id.sifa.profile.position` required array. Keep `minLength: 1` so it stays non-empty when present. Description updated to document when to omit it.

## Why

Self-employed, freelance, contract, and independent-work entries often have no separately named/registered company (e.g. German GewA 1 registration without a named entity). Forcing the field produces junk values. See singi-labs/sifa-workspace#208 for the full research (LinkedIn/Xing/JSON Resume comparison + employment-verification analysis).

Company stays conditionally required in the UI/SDK, keyed to the **Independent** employment-type group — that logic lands in sifa-sdk + sifa-web.

## Version

0.6.2 → **0.7.0** (minor). Relaxing a required constraint is a semantics change for consumers that assumed company is always present. Existing records remain valid → no migration.

## Tests

Updated the required-array assertion; added two: company not in required, company remains a non-empty string property when present. 207/207 pass, typecheck + lint clean. Generated types now emit `company?: string`.

Refs singi-labs/sifa-workspace#208