### PR TITLE
fix(publish): self-heal the rotated OAuth refresh token

### DIFF
--- a/.github/workflows/publish-lexicons.yml
+++ b/.github/workflows/publish-lexicons.yml
@@ -42,4 +42,10 @@ jobs:
           LEXICON_PUBLISHER_REFRESH_TOKEN: ${{ secrets.LEXICON_PUBLISHER_REFRESH_TOKEN }}
           LEXICON_PUBLISHER_DPOP_KEY_JWK: ${{ secrets.LEXICON_PUBLISHER_DPOP_KEY_JWK }}
           LEXICON_PUBLISHER_TOKEN_SET: ${{ secrets.LEXICON_PUBLISHER_TOKEN_SET }}
+          # Optional: a fine-grained PAT with Secrets: read+write on this repo.
+          # When present, the publish script writes the rotated (single-use)
+          # refresh token back to the LEXICON_PUBLISHER_* secrets so the next
+          # run authenticates cleanly. Without it, the job warns and the token
+          # must be re-bootstrapped manually. See sifa-lexicons#58.
+          LEXICON_PUBLISHER_SECRETS_PAT: ${{ secrets.LEXICON_PUBLISHER_SECRETS_PAT }}
         run: npm run publish:lexicons

--- a/scripts/oauth-session.ts
+++ b/scripts/oauth-session.ts
@@ -38,7 +38,19 @@ function makeMemoryStore<V extends NonNullable<unknown> | null>() {
   };
 }
 
-export async function restoreOAuthSession(): Promise<OAuthSession> {
+export interface RestoredSession {
+  session: OAuthSession;
+  did: string;
+  /**
+   * Reads the current saved session from the in-memory store. The OAuth client
+   * writes the rotated token set here whenever it refreshes, so calling this
+   * AFTER the publish work captures the new (single-use) refresh token that
+   * must be persisted for the next run.
+   */
+  readSavedSession: () => Promise<NodeSavedSession | undefined>;
+}
+
+export async function restoreOAuthSession(): Promise<RestoredSession> {
   const did = requireEnv('LEXICON_PUBLISHER_DID');
   const dpopJwk = JSON.parse(requireEnv('LEXICON_PUBLISHER_DPOP_KEY_JWK'));
   const tokenSet = JSON.parse(requireEnv('LEXICON_PUBLISHER_TOKEN_SET'));
@@ -62,5 +74,10 @@ export async function restoreOAuthSession(): Promise<OAuthSession> {
     sessionStore,
   });
 
-  return await client.restore(did, 'auto');
+  const session = await client.restore(did, 'auto');
+  return {
+    session,
+    did,
+    readSavedSession: async () => sessionStore.get(did),
+  };
 }

--- a/scripts/persist-token.ts
+++ b/scripts/persist-token.ts
@@ -1,0 +1,91 @@
+/**
+ * Persist a rotated OAuth token set back to the publisher's GitHub Actions
+ * secrets.
+ *
+ * Why this exists: atproto OAuth refresh tokens are single-use and rotate on
+ * every refresh. The publish job restores the session from the
+ * LEXICON_PUBLISHER_* secrets, the client refreshes (rotating the token), and
+ * the new token lives only in memory. Without writing it back, the next run
+ * replays the now-consumed token and the PDS rejects it with
+ * `invalid_grant: Refresh token replayed`. See sifa-lexicons#58.
+ */
+import { execFile } from 'node:child_process';
+
+type SavedTokenSet = { refresh_token?: string } | undefined;
+
+/**
+ * True when the OAuth client rotated the refresh token during this run, so the
+ * new value must be written back to the GitHub Actions secret.
+ */
+export function refreshTokenChanged(
+  previousRefreshToken: string | undefined,
+  savedTokenSet: SavedTokenSet,
+): boolean {
+  const next = savedTokenSet?.refresh_token;
+  return Boolean(next && next !== previousRefreshToken);
+}
+
+/** Set a GitHub Actions repo secret via the gh CLI (value passed on stdin, never argv). */
+function ghSecretSet(name: string, value: string, repo: string, token: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      'gh',
+      ['secret', 'set', name, '--repo', repo],
+      { env: { ...process.env, GH_TOKEN: token } },
+      (err) => (err ? reject(err) : resolve()),
+    );
+    child.stdin?.end(value);
+  });
+}
+
+/**
+ * Persist a rotated OAuth token set back to the publisher's GitHub Actions
+ * secrets. No-ops (with a clear warning) when no rotation is detected or when
+ * the persistence PAT isn't configured -- so behaviour is never worse than
+ * before, and self-heals once LEXICON_PUBLISHER_SECRETS_PAT is added.
+ */
+export async function persistRotatedTokenSet(
+  savedTokenSet: SavedTokenSet,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (!savedTokenSet) {
+    console.warn('No saved session after publish -- cannot check for token rotation.');
+    return;
+  }
+  if (!refreshTokenChanged(env.LEXICON_PUBLISHER_REFRESH_TOKEN, savedTokenSet)) {
+    console.log('Refresh token unchanged; no secret update needed.');
+    return;
+  }
+  const token = env.LEXICON_PUBLISHER_SECRETS_PAT;
+  const repo = env.GITHUB_REPOSITORY;
+  if (!token || !repo) {
+    console.warn(
+      'Refresh token rotated but LEXICON_PUBLISHER_SECRETS_PAT / GITHUB_REPOSITORY are not set. ' +
+        'The new token was not persisted, so the next run will fail with "Refresh token replayed". ' +
+        'Add a fine-grained PAT (Secrets: read+write on sifa-lexicons) as LEXICON_PUBLISHER_SECRETS_PAT ' +
+        'to enable self-healing, or re-bootstrap manually (npm run publish:bootstrap).',
+    );
+    return;
+  }
+  try {
+    await ghSecretSet('LEXICON_PUBLISHER_TOKEN_SET', JSON.stringify(savedTokenSet), repo, token);
+    if (savedTokenSet.refresh_token) {
+      await ghSecretSet(
+        'LEXICON_PUBLISHER_REFRESH_TOKEN',
+        savedTokenSet.refresh_token,
+        repo,
+        token,
+      );
+    }
+    console.log('Persisted rotated OAuth token set to GitHub Actions secrets (self-heal).');
+  } catch (err) {
+    // Don't fail the publish over a persistence error -- the records are already
+    // published and the rotation already happened. Warn loudly instead.
+    console.warn(
+      'Failed to persist the rotated token to GitHub Actions secrets:',
+      err,
+      '\nThe next run will likely fail with "Refresh token replayed". ' +
+        'Re-bootstrap manually (npm run publish:bootstrap) or fix the gh CLI error above.',
+    );
+  }
+}

--- a/scripts/publish-lexicons.ts
+++ b/scripts/publish-lexicons.ts
@@ -13,6 +13,7 @@ import { Agent } from '@atproto/api';
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { restoreOAuthSession } from './oauth-session.js';
+import { persistRotatedTokenSet } from './persist-token.js';
 
 const LEXICONS_DIR = new URL('../lexicons/', import.meta.url).pathname;
 const COLLECTION = 'com.atproto.lexicon.schema';
@@ -85,10 +86,15 @@ async function publish() {
   const check = process.argv.includes('--check');
 
   console.log('Restoring OAuth session...');
-  const session = await restoreOAuthSession();
+  const { session, did, readSavedSession } = await restoreOAuthSession();
   const agent = new Agent(session);
-  const repo = session.did;
+  const repo = did;
   console.log('Authenticated as', repo);
+
+  // restore() may have rotated the single-use refresh token. Persist the new
+  // token set back to the GitHub secret now, before any publish work, so a
+  // later failure can't strand it and replay on the next run (sifa-lexicons#58).
+  await persistRotatedTokenSet((await readSavedSession())?.tokenSet);
 
   const local = await loadLocalLexicons();
   console.log(`Loaded ${local.size} local lexicons`);

--- a/tests/persist-token.test.ts
+++ b/tests/persist-token.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { refreshTokenChanged } from '../scripts/persist-token.js';
+
+describe('refreshTokenChanged', () => {
+  it('is true when the saved refresh token differs from the previous one', () => {
+    expect(refreshTokenChanged('old-token', { refresh_token: 'new-token' })).toBe(true);
+  });
+
+  it('is true when there was no previous token but a new one exists', () => {
+    expect(refreshTokenChanged(undefined, { refresh_token: 'new-token' })).toBe(true);
+  });
+
+  it('is false when the refresh token is unchanged', () => {
+    expect(refreshTokenChanged('same-token', { refresh_token: 'same-token' })).toBe(false);
+  });
+
+  it('is false when the saved session has no refresh token', () => {
+    expect(refreshTokenChanged('old-token', {})).toBe(false);
+    expect(refreshTokenChanged('old-token', undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`publish-lexicons` fails with `invalid_grant: Refresh token replayed` on every lexicon merge after the first post-bootstrap (last clean publish #51; #57 failed). atproto OAuth refresh tokens are single-use and rotate on each refresh — the job restored the session, the client rotated the token in memory, and the new value was thrown away, so the next run replayed the consumed token.

## Fix

After `client.restore()`, persist the rotated token set back to the `LEXICON_PUBLISHER_*` GitHub Actions secrets via `gh secret set`, gated on an optional `LEXICON_PUBLISHER_SECRETS_PAT`.

- **Graceful degradation:** no PAT → logs a clear warning instead of silently replaying. Never worse than today; self-heals once the PAT exists.
- Persisted right after restore (before publish work) so a later failure can't strand the new token.
- Persistence errors are caught — they can't fail an otherwise-successful publish (CodeRabbit Major, addressed).
- Pure rotation-detection logic (`refreshTokenChanged`) is unit-tested.

## Manual steps to fully resolve #58

1. **Re-bootstrap** (unblocks now): `npm run publish:bootstrap <authority-did>`, then update the 4 `LEXICON_PUBLISHER_*` secrets. (Interactive OAuth login — needs the authority account.)
2. **Enable self-heal** (optional but recommended): create a fine-grained PAT scoped to sifa-lexicons with **Secrets: read+write**, add it as `LEXICON_PUBLISHER_SECRETS_PAT`. Then CI never needs a manual re-bootstrap again.

Closes #58