### PR TITLE
feat(profile): add credential ref to id.sifa.profile.course

### DIFF
--- a/lexicons/id/sifa/profile/course.json
+++ b/lexicons/id/sifa/profile/course.json
@@ -35,6 +35,11 @@
             "ref": "com.atproto.repo.strongRef",
             "description": "Reference to the associated id.sifa.profile.education record, if applicable."
           },
+          "credential": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the associated id.sifa.profile.certification record (the credential earned from this course), if applicable. A plain at-uri rather than a strongRef so the link tracks the live certification across edits."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.6.2",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.6.2",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Change

Adds an optional `credential` field to `id.sifa.profile.course` (link 1 of 4 for the course-to-credential association feature).

It holds the **at-uri** of the associated `id.sifa.profile.certification` record (the credential earned from the course). Plain at-uri, not a strongRef, so the link tracks the live certification across edits rather than pinning a CID that goes stale when the cert is edited. (The repo's strongRef guideline is a general default for inter-record refs; a "points at my current credential" association is a deliberate exception, confirmed by the maintainer.)

Additive and optional. Patch bump 0.7.0 → 0.7.1. No breaking change, no migration concern for existing records.

## Verification

- `npm run generate` regenerates types (the `credential?: string` field appears in the generated course type).
- `npm run validate`, `typecheck`, `lint`: clean.
- Tests: 211 pass.

## Follow-ups (rest of the chain)

- sifa-sdk: add `credential` to the Zod record schema + `ProfileCourse` view type.
- sifa-api: migration + indexer mapping + echo `credentialRkey` in the profile response.
- sifa-web: cert picker in the course editor, render the link, sort linked courses by the credential's date.