### PR TITLE
feat(lexicons): add presentation + presentationDelivery records

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -568,6 +568,100 @@
     "projectArchived": {
       "type": "token",
       "description": "Project is archived and no longer active."
+    },
+
+    "externalRecordRef": {
+      "type": "object",
+      "description": "A reference to a record in another repository or lexicon by AT-URI. The CID is optional: it pins a specific version as an integrity hint, but consumers should resolve the AT-URI live so the reference tracks edits to the target.",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of the referenced record."
+        },
+        "cid": {
+          "type": "string",
+          "format": "cid",
+          "description": "Optional CID of a specific version of the referenced record. Used as an integrity hint only; live resolution is by AT-URI."
+        }
+      }
+    },
+
+    "presentationRole": {
+      "type": "string",
+      "description": "The user's role in a presentation or session. Open set.",
+      "knownValues": [
+        "id.sifa.defs#presenter",
+        "id.sifa.defs#panelist",
+        "id.sifa.defs#keynote",
+        "id.sifa.defs#workshop",
+        "id.sifa.defs#host"
+      ]
+    },
+    "presenter": {
+      "type": "token",
+      "description": "Delivered the session as the speaker or presenter (spoken or non-spoken)."
+    },
+    "panelist": { "type": "token", "description": "Participated as a member of a panel." },
+    "keynote": { "type": "token", "description": "Gave a keynote address." },
+    "workshop": { "type": "token", "description": "Led or facilitated a workshop or tutorial." },
+    "host": { "type": "token", "description": "Hosted or moderated the session." },
+
+    "presentationLinkType": {
+      "type": "string",
+      "description": "The category of a related link on a presentation. Open set.",
+      "knownValues": [
+        "id.sifa.defs#linkSlides",
+        "id.sifa.defs#linkRecording",
+        "id.sifa.defs#linkEvent",
+        "id.sifa.defs#linkRegistration",
+        "id.sifa.defs#linkWriteup",
+        "id.sifa.defs#linkOther"
+      ]
+    },
+    "linkSlides": { "type": "token", "description": "Slides or presentation deck." },
+    "linkRecording": {
+      "type": "token",
+      "description": "Video or audio recording of the presentation."
+    },
+    "linkEvent": { "type": "token", "description": "The event or session page." },
+    "linkRegistration": { "type": "token", "description": "Registration or ticket page." },
+    "linkWriteup": {
+      "type": "token",
+      "description": "A long-form write-up, article, or transcript of the talk."
+    },
+    "linkOther": { "type": "token", "description": "Other related link." },
+
+    "presentationLink": {
+      "type": "object",
+      "description": "A related link for a presentation or one of its deliveries.",
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link URL."
+        },
+        "label": {
+          "type": "string",
+          "maxGraphemes": 64,
+          "maxLength": 640,
+          "description": "Optional display label (e.g., 'Watch recording', 'Slides')."
+        },
+        "type": {
+          "type": "string",
+          "description": "Optional link category, used to pick an icon. Open set; see id.sifa.defs#presentationLinkType.",
+          "knownValues": [
+            "id.sifa.defs#linkSlides",
+            "id.sifa.defs#linkRecording",
+            "id.sifa.defs#linkEvent",
+            "id.sifa.defs#linkRegistration",
+            "id.sifa.defs#linkWriteup",
+            "id.sifa.defs#linkOther"
+          ]
+        }
+      }
     }
   }
 }

--- a/lexicons/id/sifa/profile/presentation.json
+++ b/lexicons/id/sifa/profile/presentation.json
@@ -1,0 +1,82 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.profile.presentation",
+  "description": "A reusable presentation: the content a person presents (a talk, workshop, poster, or demo), independent of any single occasion on which it is delivered. Delivered at one or more id.sifa.profile.presentationDelivery occasions.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing a single reusable presentation (the content), distinct from the occasions on which it is delivered.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["title", "createdAt"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxGraphemes": 300,
+            "maxLength": 3000,
+            "description": "Title of the presentation."
+          },
+          "description": {
+            "type": "string",
+            "maxGraphemes": 5000,
+            "maxLength": 50000,
+            "description": "Description or abstract of the presentation."
+          },
+          "duration": {
+            "type": "ref",
+            "ref": "#duration",
+            "description": "Typical length of the presentation, a fixed value or a range, in minutes."
+          },
+          "intendedAudiences": {
+            "type": "array",
+            "maxLength": 20,
+            "items": {
+              "type": "string",
+              "maxGraphemes": 100,
+              "maxLength": 1000
+            },
+            "description": "Intended audiences for this presentation, open text (e.g. 'Engineering leaders', 'Beginners')."
+          },
+          "links": {
+            "type": "array",
+            "maxLength": 20,
+            "items": {
+              "type": "ref",
+              "ref": "id.sifa.defs#presentationLink"
+            },
+            "description": "Canonical links for this content, such as slides or a recording."
+          },
+          "writeupRef": {
+            "type": "ref",
+            "ref": "id.sifa.defs#externalRecordRef",
+            "description": "Optional reference to a long-form write-up of this presentation (a pub.leaflet.document or site.standard.document holding video, transcript, or article)."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was originally created."
+          }
+        }
+      }
+    },
+    "duration": {
+      "type": "object",
+      "description": "A presentation length in minutes: a fixed value (minMinutes only) or a range (minMinutes to maxMinutes).",
+      "required": ["minMinutes"],
+      "properties": {
+        "minMinutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Length in minutes, or the lower bound when the length is offered as a range."
+        },
+        "maxMinutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Upper bound in minutes when the length is offered as a range. Omit for a fixed length."
+        }
+      }
+    }
+  }
+}

--- a/lexicons/id/sifa/profile/presentationDelivery.json
+++ b/lexicons/id/sifa/profile/presentationDelivery.json
@@ -1,0 +1,98 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.profile.presentationDelivery",
+  "description": "An occasion on which a person delivered a presentation: a specific talk, panel, workshop, or demo at an event. References the reusable id.sifa.profile.presentation content and, optionally, the calendar event.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing a single occasion on which a presentation was delivered. This is the entry shown on a profile's activity timeline. At least one of presentationRef, title, or eventName is expected, enforced at the app layer.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["createdAt"],
+        "properties": {
+          "presentationRef": {
+            "type": "ref",
+            "ref": "id.sifa.defs#externalRecordRef",
+            "description": "Optional reference to the id.sifa.profile.presentation (the content) delivered here. When set, title, duration, and audiences are taken from it."
+          },
+          "title": {
+            "type": "string",
+            "maxGraphemes": 300,
+            "maxLength": 3000,
+            "description": "Fallback title for this delivery, used when no presentationRef is set."
+          },
+          "role": {
+            "type": "string",
+            "maxGraphemes": 64,
+            "maxLength": 640,
+            "description": "The presenter's role in this delivery. Open set; see id.sifa.defs#presentationRole.",
+            "knownValues": [
+              "id.sifa.defs#presenter",
+              "id.sifa.defs#panelist",
+              "id.sifa.defs#keynote",
+              "id.sifa.defs#workshop",
+              "id.sifa.defs#host"
+            ]
+          },
+          "eventName": {
+            "type": "string",
+            "maxGraphemes": 300,
+            "maxLength": 3000,
+            "description": "Name of the event or venue. On the linked branch, hydrated from the calendar event's name."
+          },
+          "date": {
+            "type": "string",
+            "maxLength": 10,
+            "description": "Calendar date of this delivery as YYYY-MM-DD (day only, no time). Future dates are allowed for upcoming deliveries. The day-only shape is enforced at the app layer. On the linked branch, derived from the event's startsAt in the event's own offset."
+          },
+          "location": {
+            "type": "string",
+            "maxGraphemes": 256,
+            "maxLength": 2560,
+            "description": "Display location (city, country, or venue). On the linked branch, composed from the calendar event's structured locations."
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether this delivery was in person, virtual, or hybrid. Stores the full community.lexicon.calendar.event mode token; absent means in person.",
+            "knownValues": [
+              "community.lexicon.calendar.event#inperson",
+              "community.lexicon.calendar.event#virtual",
+              "community.lexicon.calendar.event#hybrid"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "description": "Scheduling status of this delivery, typically hydrated from a linked calendar event. Stores the full community.lexicon.calendar.event status token. Consumers should surface cancelled and postponed states.",
+            "knownValues": [
+              "community.lexicon.calendar.event#scheduled",
+              "community.lexicon.calendar.event#cancelled",
+              "community.lexicon.calendar.event#postponed",
+              "community.lexicon.calendar.event#rescheduled",
+              "community.lexicon.calendar.event#planned"
+            ]
+          },
+          "links": {
+            "type": "array",
+            "maxLength": 20,
+            "items": {
+              "type": "ref",
+              "ref": "id.sifa.defs#presentationLink"
+            },
+            "description": "Links specific to this delivery, such as the recording of this occasion."
+          },
+          "eventRef": {
+            "type": "ref",
+            "ref": "id.sifa.defs#externalRecordRef",
+            "description": "Optional reference to a community.lexicon.calendar.event for this occasion. Display fields are hydrated live from the target by AT-URI, with the stored fields as a fallback when the target is unavailable."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/well-known/activity-tiers.json
+++ b/well-known/activity-tiers.json
@@ -284,6 +284,8 @@
     "id.sifa.profile.language": { "tier": "creation", "app": "sifa" },
     "id.sifa.profile.externalAccount": { "tier": "creation", "app": "sifa" },
     "id.sifa.profile.location": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.presentation": { "tier": "creation", "app": "sifa" },
+    "id.sifa.profile.presentationDelivery": { "tier": "creation", "app": "sifa" },
     "id.sifa.endorsement": {
       "tier": "creation",
       "app": "sifa",


### PR DESCRIPTION
Models a presentation in two records, so the reusable content is separate from each occasion it is delivered. A presentation (the content) can be delivered at many occasions; an occasion can reference the calendar event it happened at.

## `id.sifa.profile.presentation` (the content)

The reusable thing you present, independent of any single occasion. Format-neutral (talk, workshop, poster, demo). Required: `title`, `createdAt`.

| Field | Type | Notes |
|---|---|---|
| `title` | string (required) | |
| `description` | string | abstract |
| `duration` | `#duration` | `{ minMinutes, maxMinutes? }`: a fixed length (min only) or a range |
| `intendedAudiences` | string[] | open text, multiple |
| `links[]` | `presentationLink` | canonical slides / recording for the content |
| `writeupRef` | ref | optional `pub.leaflet.document` / `site.standard.document` |

## `id.sifa.profile.presentationDelivery` (the occasion)

One per time the presentation was delivered. This is the entry shown on the activity timeline. Works standalone or linked to a content record and/or a calendar event.

| Field | Type | Notes |
|---|---|---|
| `presentationRef` | ref | optional → the content record; when set, title/duration/audiences come from it |
| `title` | string | fallback title when there is no `presentationRef` |
| `role` | open enum | presenter / panelist / keynote / workshop / host (per delivery) |
| `eventName` | string | conference or venue |
| `date` | string | `YYYY-MM-DD`, day only, future dates allowed |
| `location` | string | |
| `mode` | enum | stores the `community.lexicon.calendar.event` mode token |
| `status` | enum | stores the `community.lexicon.calendar.event` status token |
| `links[]` | `presentationLink` | a recording of this specific delivery |
| `eventRef` | ref | optional → a `community.lexicon.calendar.event` |

## Added to `id.sifa.defs`

- `externalRecordRef`: a foreign-record pointer, `uri` required and `cid` **optional**, so a consumer resolves the AT-URI live (tracking edits) while keeping an integrity hint.
- `presentationLink`: `{ uri, label?, type? }` with `type` an open enum.
- `presentationRole` and `presentationLinkType` enums and their tokens.

`mode` and `status` reuse the upstream `community.lexicon.calendar.event` tokens directly rather than forking them. Both records are registered as creation-tier in `well-known/activity-tiers.json`.

## Versioning

Minor bump to `0.8.0` (new lexicon files).

## Validation

`npm test` (225 passing), `npm run validate` (lex-cli codegen), `build`, `typecheck`, and `lint` all pass.

Refs singi-labs/sifa-workspace#214
