### PR TITLE
feat(lexicons): add coSpeakers to presentationDelivery

### DIFF
--- a/lexicons/id/sifa/profile/presentationDelivery.json
+++ b/lexicons/id/sifa/profile/presentationDelivery.json
@@ -86,6 +86,15 @@
             "ref": "id.sifa.defs#externalRecordRef",
             "description": "Optional reference to a community.lexicon.calendar.event for this occasion. Display fields are hydrated live from the target by AT-URI, with the stored fields as a fallback when the target is unavailable."
           },
+          "coSpeakers": {
+            "type": "array",
+            "maxLength": 20,
+            "items": {
+              "type": "string",
+              "format": "did"
+            },
+            "description": "DIDs of co-speakers who presented alongside the author at this occasion. Any atproto account is allowed; hydrated to profile cards on read and linked to the co-speaker's Sifa profile."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Adds an optional `coSpeakers` field to `id.sifa.profile.presentationDelivery`: an array of DIDs (max 20) recording who presented alongside the author at that occasion.

- Any atproto account is allowed (`format: did`), following the same DID-reference pattern as `id.sifa.endorsement.subject`.
- Consumers hydrate the DIDs to profile cards and link each to the co-speaker's Sifa profile (which renders for unclaimed atproto accounts too).
- Additive, backward-compatible; patch bump to 0.8.1.

First step of the co-speakers feature (lexicon → SDK → API → web).