### PR TITLE
feat(position): add optional entityRef for portable org entity identity

### DIFF
--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -23,6 +23,11 @@
             "format": "did",
             "description": "DID of the company's ATproto account, if one exists. Enables verified company linking."
           },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the organization the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the org claims an ATproto account. Absent for free-text or independent/self-employed positions."
+          },
           "title": {
             "type": "string",
             "minLength": 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.8.0",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -278,6 +278,27 @@ describe('Position skills field', () => {
   });
 });
 
+describe('Position entityRef field', () => {
+  const positionLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.position');
+  const properties = positionLexicon?.doc.defs.main.record?.properties;
+  const required = positionLexicon?.doc.defs.main.record?.required ?? [];
+
+  it('entityRef exists as an optional string with uri format', () => {
+    expect(properties?.entityRef).toBeDefined();
+    expect(properties?.entityRef?.type).toBe('string');
+    expect(properties?.entityRef?.format).toBe('uri');
+  });
+
+  it('entityRef is not required (absent for freetext/Independent positions)', () => {
+    expect(required).not.toContain('entityRef');
+  });
+
+  it('entityRef has a description mentioning the portable entity identifier', () => {
+    expect(properties?.entityRef?.description).toBeDefined();
+    expect(properties?.entityRef?.description!.length).toBeGreaterThan(0);
+  });
+});
+
 describe('id.sifa.profile.self presentation overrides', () => {
   const selfLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.self');
   const properties = selfLexicon?.doc.defs.main.record?.properties;


### PR DESCRIPTION
## What

Adds an optional `entityRef` field (string, `format: uri`) to `id.sifa.profile.position`.

It carries a portable, app-neutral organization identifier — a Wikidata Q-ID URI (`http://www.wikidata.org/entity/Q…`), a ROR URI, or an LEI URI. The field is written when a user selects an organization from a resolver dropdown, and stays absent for free-text or independent/self-employed positions.

## Why

Part of #159 (organization entity resolution). `entityRef` lets the AppView resolve unclaimed organizations to a canonical entity deterministically, with zero PDS rewrites when those orgs later claim an ATproto account. The `company` string remains the user's display label; `companyDid` stays the verified-claim path.

## Scope

- Additive, backward-compatible field. Existing position records validate unchanged.
- Patch bump `0.8.1` → `0.8.2`.
- First PR in the #159 spec breakdown (lexicon foundation for the api/sdk/web work that follows).

## Tests

New `Position entityRef field` block asserts the field is an optional `string`/`uri`, not required, and documented. Full suite: 228 passing; typecheck, lint, format clean.