### PR TITLE
feat(publication): add optional subtitle field

### DIFF
--- a/lexicons/id/sifa/profile/publication.json
+++ b/lexicons/id/sifa/profile/publication.json
@@ -18,6 +18,12 @@
             "maxLength": 2000,
             "description": "Publication title."
           },
+          "subtitle": {
+            "type": "string",
+            "maxGraphemes": 200,
+            "maxLength": 2000,
+            "description": "Publication subtitle. Carries the distinguishing part of a title that sources such as Crossref and ORCID store separately from the main title -- for example the volume/part designation and descriptive clause of a multi-part paper series (\"III. Using cluster masses to create a cleaned catalogue\"). Absent for publications with no subtitle."
+          },
           "publisher": {
             "type": "string",
             "maxGraphemes": 256,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -104,6 +104,7 @@ const USER_TEXT_FIELDS = new Set([
   'company',
   'companyName',
   'title',
+  'subtitle',
   'institution',
   'name',
   'comment',
@@ -296,6 +297,31 @@ describe('Position entityRef field', () => {
   it('entityRef has a description mentioning the portable entity identifier', () => {
     expect(properties?.entityRef?.description).toBeDefined();
     expect(properties?.entityRef?.description!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Publication subtitle field', () => {
+  const publicationLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.publication');
+  const properties = publicationLexicon?.doc.defs.main.record?.properties;
+  const required = publicationLexicon?.doc.defs.main.record?.required ?? [];
+
+  it('subtitle exists as an optional string', () => {
+    expect(properties?.subtitle).toBeDefined();
+    expect(properties?.subtitle?.type).toBe('string');
+  });
+
+  it('subtitle matches title length constraints (200/2000)', () => {
+    expect(properties?.subtitle?.maxGraphemes).toBe(200);
+    expect(properties?.subtitle?.maxLength).toBe(2000);
+  });
+
+  it('subtitle is not required (many publications have none)', () => {
+    expect(required).not.toContain('subtitle');
+  });
+
+  it('subtitle has a description', () => {
+    expect(properties?.subtitle?.description).toBeDefined();
+    expect(properties?.subtitle?.description!.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
Adds an optional `subtitle` to `id.sifa.profile.publication`.

Crossref and ORCID store a publication's subtitle separately from its main title. This is most visible for multi-part paper series, where several entries share one title (e.g. "Improving the open cluster census") and are distinguished only by their subtitle ("I.", "II.", "III." plus a descriptive clause). Without the field, those collapse into identical-looking entries on a profile.

`subtitle` mirrors `title`'s length constraints (200 graphemes / 2000 bytes) and is not required. Additive and backward-compatible → patch bump 0.8.2 → 0.8.3.

First repo in the chain; sifa-sdk, sifa-api, and sifa-web follow.

Refs singi-labs/sifa-workspace#227