### PR TITLE
feat(profile): add optional entityRef to five org-bearing sections (#241)

### DIFF
--- a/lexicons/id/sifa/profile/certification.json
+++ b/lexicons/id/sifa/profile/certification.json
@@ -29,6 +29,11 @@
             "format": "did",
             "description": "DID of the issuing authority's ATproto account, if one exists."
           },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the issuing organization the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the organization claims an ATproto account. Absent for free-text entries."
+          },
           "credentialId": {
             "type": "string",
             "maxGraphemes": 256,

--- a/lexicons/id/sifa/profile/course.json
+++ b/lexicons/id/sifa/profile/course.json
@@ -30,6 +30,11 @@
             "maxLength": 2560,
             "description": "Institution or platform offering the course."
           },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the institution or platform the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the organization claims an ATproto account. Absent for free-text entries."
+          },
           "education": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",

--- a/lexicons/id/sifa/profile/education.json
+++ b/lexicons/id/sifa/profile/education.json
@@ -23,6 +23,11 @@
             "format": "did",
             "description": "DID of the institution's ATproto account, if one exists."
           },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the educational institution the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the institution claims an ATproto account. Absent for free-text entries."
+          },
           "degree": {
             "type": "string",
             "maxGraphemes": 256,

--- a/lexicons/id/sifa/profile/honor.json
+++ b/lexicons/id/sifa/profile/honor.json
@@ -29,6 +29,11 @@
             "format": "did",
             "description": "DID of the issuing entity's ATproto account, if one exists."
           },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the issuing organization the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the organization claims an ATproto account. Absent for free-text entries."
+          },
           "description": {
             "type": "string",
             "maxGraphemes": 5000,

--- a/lexicons/id/sifa/profile/volunteering.json
+++ b/lexicons/id/sifa/profile/volunteering.json
@@ -23,6 +23,11 @@
             "format": "did",
             "description": "DID of the organization's ATproto account, if one exists."
           },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the organization the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the organization claims an ATproto account. Absent for free-text entries."
+          },
           "role": {
             "type": "string",
             "maxGraphemes": 256,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -300,6 +300,33 @@ describe('Position entityRef field', () => {
   });
 });
 
+describe.each([
+  'id.sifa.profile.education',
+  'id.sifa.profile.volunteering',
+  'id.sifa.profile.certification',
+  'id.sifa.profile.course',
+  'id.sifa.profile.honor',
+])('%s entityRef field', (lexiconId) => {
+  const lexicon = recordLexicons.find((l) => l.doc.id === lexiconId);
+  const properties = lexicon?.doc.defs.main.record?.properties;
+  const required = lexicon?.doc.defs.main.record?.required ?? [];
+
+  it('entityRef exists as an optional string with uri format', () => {
+    expect(properties?.entityRef).toBeDefined();
+    expect(properties?.entityRef?.type).toBe('string');
+    expect(properties?.entityRef?.format).toBe('uri');
+  });
+
+  it('entityRef is not required (absent for free-text entries)', () => {
+    expect(required).not.toContain('entityRef');
+  });
+
+  it('entityRef has a description mentioning the portable entity identifier', () => {
+    expect(properties?.entityRef?.description).toBeDefined();
+    expect(properties?.entityRef?.description!.length).toBeGreaterThan(0);
+  });
+});
+
 describe('Publication subtitle field', () => {
   const publicationLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.publication');
   const properties = publicationLexicon?.doc.defs.main.record?.properties;


### PR DESCRIPTION
## Summary

Adds an optional `entityRef` field to the five other org-bearing profile section lexicons, mirroring the field already on `id.sifa.profile.position`. This is the lexicon half of epic #241 phase A/B (foundation), extending the durable, portable org pointer beyond career positions.

Sections updated (org field left unchanged, `entityRef` added alongside):

- `id.sifa.profile.education` (`institution` + `institutionDid`)
- `id.sifa.profile.volunteering` (`organization` + `organizationDid`)
- `id.sifa.profile.certification` (`authority` + `authorityDid`)
- `id.sifa.profile.course` (`institution`, free-text only)
- `id.sifa.profile.honor` (`issuer` + `issuerDid`)

## Field shape

Identical to `position`'s `entityRef`: `type: string`, `format: uri`, optional, with a section-appropriate description. Carries a portable, app-neutral organization identifier (Wikidata Q-ID URI, ROR URI, or LEI URI) written when a user picks an org from a resolver dropdown; absent for free-text entries.

## Change type

Additive, backward-compatible field. Patch bump `0.8.3` -> `0.8.4`.

## Tests

`tests/lexicons.test.ts` gains a parametrized block asserting `entityRef` exists as an optional `string`/`uri` on all five sections and is not required. Full suite: 248 passing. Lint, typecheck, generate, and format all pass.

## Notes

- No existing field renamed. Legacy `*Did` fields kept.
- Schemas are auto-republished to the authority DID's PDS on merge.

Part of #241. Refs #159.
