### PR TITLE
feat(profile): add id.sifa.profile.involvement lexicon

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -662,6 +662,76 @@
           ]
         }
       }
+    },
+
+    "involvementKind": {
+      "type": "string",
+      "description": "The nature of an involvement record.",
+      "knownValues": [
+        "id.sifa.defs#involvementOpenSource",
+        "id.sifa.defs#involvementCommunity",
+        "id.sifa.defs#involvementCharity",
+        "id.sifa.defs#involvementCivic",
+        "id.sifa.defs#involvementOther"
+      ]
+    },
+    "involvementOpenSource": {
+      "type": "token",
+      "description": "Open-source contribution or maintainership."
+    },
+    "involvementCommunity": {
+      "type": "token",
+      "description": "Community organizing, moderation, or meetup/event running."
+    },
+    "involvementCharity": {
+      "type": "token",
+      "description": "Charitable or volunteer work for a cause or person."
+    },
+    "involvementCivic": {
+      "type": "token",
+      "description": "Board membership, policy, advisory, or public-consultation work."
+    },
+    "involvementOther": {
+      "type": "token",
+      "description": "Other uncompensated involvement."
+    },
+
+    "artifactLink": {
+      "type": "object",
+      "description": "A public artifact proving a piece of work. Reusable across involvement, and later projects/publications.",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the artifact."
+        },
+        "kind": {
+          "type": "string",
+          "description": "What this link points to.",
+          "knownValues": [
+            "pull-request",
+            "issue",
+            "commit",
+            "review",
+            "release",
+            "talk",
+            "video",
+            "slides",
+            "article",
+            "thread",
+            "dataset",
+            "edit",
+            "other"
+          ]
+        },
+        "label": {
+          "type": "string",
+          "maxGraphemes": 200,
+          "maxLength": 2000,
+          "description": "Optional human-readable label (e.g. 'Merged PR #1234: keep-alive support')."
+        }
+      }
     }
   }
 }

--- a/lexicons/id/sifa/profile/involvement.json
+++ b/lexicons/id/sifa/profile/involvement.json
@@ -1,0 +1,81 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.profile.involvement",
+  "description": "Uncompensated involvement with an external project, community, event, or cause the user does not own or run — open-source, community, charity, or civic work. Distinct from paid roles (position), things you own (project), and paid employment.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing one involvement — an ongoing role and/or a body of discrete contributions to a single upstream.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["kind", "createdAt"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "The nature of the involvement. Drives the display heading (Open Source / Community / Volunteering / Civic).",
+            "knownValues": [
+              "id.sifa.defs#involvementOpenSource",
+              "id.sifa.defs#involvementCommunity",
+              "id.sifa.defs#involvementCharity",
+              "id.sifa.defs#involvementCivic",
+              "id.sifa.defs#involvementOther"
+            ]
+          },
+          "upstream": {
+            "type": "string",
+            "maxGraphemes": 256,
+            "maxLength": 2560,
+            "description": "Name of the project, community, event, or cause (e.g. 'atproto', 'Linux kernel', 'PyCon NL'). Optional — a one-off contribution need not name an organization."
+          },
+          "upstreamDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the upstream's ATproto account, if one exists."
+          },
+          "upstreamUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Primary URL of the upstream (project homepage, repo, event site)."
+          },
+          "role": {
+            "type": "string",
+            "maxGraphemes": 256,
+            "maxLength": 2560,
+            "description": "The user's role (e.g. 'Maintainer', 'Translator', 'Organizer', 'Contributor')."
+          },
+          "description": {
+            "type": "string",
+            "maxGraphemes": 5000,
+            "maxLength": 50000,
+            "description": "What the user did and why it mattered."
+          },
+          "startedAt": {
+            "type": "string",
+            "description": "Start date in YYYY-MM or YYYY-MM-DD format. Freeform (NOT strict datetime) to allow partial dates and importer writes."
+          },
+          "endedAt": {
+            "type": "string",
+            "description": "End date in YYYY-MM or YYYY-MM-DD format. Omit if ongoing."
+          },
+          "links": {
+            "type": "array",
+            "maxLength": 50,
+            "description": "Public artifacts proving the involvement (PRs, releases, talk recordings, published translations).",
+            "items": { "type": "ref", "ref": "id.sifa.defs#artifactLink" }
+          },
+          "labels": {
+            "type": "union",
+            "description": "Self-label values for this record.",
+            "refs": ["com.atproto.label.defs#selfLabels"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -201,6 +201,8 @@ const DATE_ONLY_FIELDS = new Set([
   'id.sifa.profile.education.endedAt',
   'id.sifa.profile.project.startedAt',
   'id.sifa.profile.project.endedAt',
+  'id.sifa.profile.involvement.startedAt',
+  'id.sifa.profile.involvement.endedAt',
 ]);
 
 describe('Timestamps use datetime format', () => {
@@ -493,6 +495,124 @@ describe('community location adoption', () => {
       expect(refs).not.toContain('id.sifa.defs#locationAddress');
     });
   }
+});
+
+describe('id.sifa.profile.involvement lexicon', () => {
+  const involvement = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.involvement');
+  const properties = involvement?.doc.defs.main.record?.properties;
+  const required = involvement?.doc.defs.main.record?.required ?? [];
+
+  it('lexicon exists as a tid-keyed record', () => {
+    expect(involvement).toBeDefined();
+    expect(involvement!.doc.defs.main.type).toBe('record');
+    expect(involvement!.doc.defs.main.key).toBe('tid');
+  });
+
+  it('requires only kind and createdAt', () => {
+    expect(required).toEqual(['kind', 'createdAt']);
+  });
+
+  it('kind is a string with the five involvement NSID tokens', () => {
+    expect(properties?.kind?.type).toBe('string');
+    expect((properties?.kind as { knownValues?: string[] })?.knownValues).toEqual([
+      'id.sifa.defs#involvementOpenSource',
+      'id.sifa.defs#involvementCommunity',
+      'id.sifa.defs#involvementCharity',
+      'id.sifa.defs#involvementCivic',
+      'id.sifa.defs#involvementOther',
+    ]);
+  });
+
+  it('upstream is an optional string (a one-off contribution need not name an org)', () => {
+    expect(properties?.upstream?.type).toBe('string');
+    expect(required).not.toContain('upstream');
+  });
+
+  it('upstreamDid is an optional did-format string', () => {
+    expect(properties?.upstreamDid?.type).toBe('string');
+    expect(properties?.upstreamDid?.format).toBe('did');
+    expect(required).not.toContain('upstreamDid');
+  });
+
+  it('upstreamUrl is an optional uri-format string', () => {
+    expect(properties?.upstreamUrl?.type).toBe('string');
+    expect(properties?.upstreamUrl?.format).toBe('uri');
+  });
+
+  it('startedAt and endedAt are freeform date strings (no datetime format, YYYY-MM documented)', () => {
+    expect(properties?.startedAt?.type).toBe('string');
+    expect(properties?.startedAt?.format).toBeUndefined();
+    expect(properties?.startedAt?.description).toMatch(/YYYY-MM/);
+    expect(properties?.endedAt?.format).toBeUndefined();
+    expect(properties?.endedAt?.description).toMatch(/YYYY-MM/);
+  });
+
+  it('links is an optional array of id.sifa.defs#artifactLink with maxLength 50', () => {
+    expect(properties?.links?.type).toBe('array');
+    expect(properties?.links?.maxLength).toBe(50);
+    expect(properties?.links?.items?.type).toBe('ref');
+    expect(properties?.links?.items?.ref).toBe('id.sifa.defs#artifactLink');
+    expect(required).not.toContain('links');
+  });
+
+  it('createdAt uses datetime format', () => {
+    expect(properties?.createdAt?.format).toBe('datetime');
+  });
+});
+
+describe('id.sifa.defs involvement additions', () => {
+  interface DefsDoc {
+    defs: Record<
+      string,
+      {
+        type: string;
+        description?: string;
+        knownValues?: string[];
+        required?: string[];
+        properties?: Record<
+          string,
+          { type: string; format?: string; knownValues?: string[]; maxGraphemes?: number }
+        >;
+      }
+    >;
+  }
+  const defs = JSON.parse(readFileSync(join(LEXICONS_DIR, 'defs.json'), 'utf-8')) as DefsDoc;
+
+  it('involvementKind is a string def with the five NSID tokens', () => {
+    expect(defs.defs.involvementKind?.type).toBe('string');
+    expect(defs.defs.involvementKind?.knownValues).toEqual([
+      'id.sifa.defs#involvementOpenSource',
+      'id.sifa.defs#involvementCommunity',
+      'id.sifa.defs#involvementCharity',
+      'id.sifa.defs#involvementCivic',
+      'id.sifa.defs#involvementOther',
+    ]);
+  });
+
+  it.each([
+    'involvementOpenSource',
+    'involvementCommunity',
+    'involvementCharity',
+    'involvementCivic',
+    'involvementOther',
+  ])('declares the %s token', (token) => {
+    expect(defs.defs[token]?.type).toBe('token');
+    expect(defs.defs[token]?.description?.length).toBeGreaterThan(0);
+  });
+
+  it('artifactLink is an object def requiring a uri-format url', () => {
+    expect(defs.defs.artifactLink?.type).toBe('object');
+    expect(defs.defs.artifactLink?.required).toEqual(['url']);
+    expect(defs.defs.artifactLink?.properties?.url?.type).toBe('string');
+    expect(defs.defs.artifactLink?.properties?.url?.format).toBe('uri');
+  });
+
+  it('artifactLink.kind is a bare-string enum and label is capped', () => {
+    expect(defs.defs.artifactLink?.properties?.kind?.type).toBe('string');
+    expect(defs.defs.artifactLink?.properties?.kind?.knownValues).toContain('pull-request');
+    expect(defs.defs.artifactLink?.properties?.kind?.knownValues).toContain('release');
+    expect(defs.defs.artifactLink?.properties?.label?.maxGraphemes).toBe(200);
+  });
 });
 
 describe('openToWorkStatus commissions token', () => {


### PR DESCRIPTION
## What

Adds `id.sifa.profile.involvement`, a new profile collection for uncompensated involvement with an external project, community, event, or cause the member does not own or run: open source, community, charity, or civic work. This gives that work its own home instead of forcing it into Volunteering, Positions, or Projects.

## Lexicon shape

- `kind` is required and drives the display heading (open source / community / charity / civic / other), using full-NSID tokens so co-writers can resolve the vocabulary from the authority DID.
- `upstream` is optional, so a one-off contribution to a repo you have no standing relationship with is not an organization you hold a role at.
- `startedAt` / `endedAt` are freeform `YYYY-MM` / `YYYY-MM-DD` strings, matching position and project, so partial dates and importer writes validate.
- `links[]` carries public artifacts (PRs, releases, recordings) via the new reusable `id.sifa.defs#artifactLink` object, which replaces the orphaned `#contributionLink`.

## defs.json

- `involvementKind` string def plus the five tokens.
- `artifactLink` object def (`url` required, optional `kind` and `label`), reusable across involvement and later projects/publications.

Legacy `id.sifa.profile.volunteering` is untouched and stays readable. The api reads both collections and backfills on edit. No migration here.

Minor bump `0.8.4` -> `0.9.0`. On merge, the publish workflow pushes the new schema record to the authority DID.

Refs #66.
