### PR TITLE
feat(profile): add entityRef, location, skills to involvement

### DIFF
--- a/lexicons/id/sifa/profile/involvement.json
+++ b/lexicons/id/sifa/profile/involvement.json
@@ -64,6 +64,22 @@
             "description": "Public artifacts proving the involvement (PRs, releases, talk recordings, published translations).",
             "items": { "type": "ref", "ref": "id.sifa.defs#artifactLink" }
           },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the upstream the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the upstream claims an ATproto account. Absent for free-text or one-off entries."
+          },
+          "location": {
+            "type": "ref",
+            "ref": "community.lexicon.location.address",
+            "description": "Where the involvement takes place. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
+          },
+          "skills": {
+            "type": "array",
+            "items": { "type": "ref", "ref": "id.sifa.defs#skillRef" },
+            "description": "Skills demonstrated by this involvement. Each entry is a URI reference to an id.sifa.profile.skill record owned by the same DID.",
+            "maxLength": 50
+          },
           "labels": {
             "type": "union",
             "description": "Self-label values for this record.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -558,6 +558,25 @@ describe('id.sifa.profile.involvement lexicon', () => {
   it('createdAt uses datetime format', () => {
     expect(properties?.createdAt?.format).toBe('datetime');
   });
+
+  it('entityRef is an optional uri-format string (portable org link, #241 pattern)', () => {
+    expect(properties?.entityRef?.type).toBe('string');
+    expect(properties?.entityRef?.format).toBe('uri');
+    expect(required).not.toContain('entityRef');
+  });
+
+  it('location is an optional community.lexicon.location.address ref', () => {
+    expect(properties?.location?.type).toBe('ref');
+    expect(properties?.location?.ref).toBe('community.lexicon.location.address');
+    expect(required).not.toContain('location');
+  });
+
+  it('skills is an optional array of id.sifa.defs#skillRef with maxLength 50', () => {
+    expect(properties?.skills?.type).toBe('array');
+    expect(properties?.skills?.maxLength).toBe(50);
+    expect(properties?.skills?.items?.ref).toBe('id.sifa.defs#skillRef');
+    expect(required).not.toContain('skills');
+  });
 });
 
 describe('id.sifa.defs involvement additions', () => {


### PR DESCRIPTION
Adds three optional fields to `id.sifa.profile.involvement`, mirroring the equivalents on `position`:

- `entityRef`: a portable, app-neutral organization identifier (Wikidata / ROR / LEI URI) from the resolver typeahead, for a durable, correctable upstream link (the #241 pattern). `upstream` stays the free-text name.
- `location`: a `community.lexicon.location.address` reference.
- `skills`: an array of `id.sifa.defs#skillRef` (max 50), so an involvement can carry the skills it demonstrates.

All optional and additive, so existing records and the dual-read stay intact. Patch bump `0.9.0` -> `0.9.1`; the publish workflow pushes the updated schema to the authority DID on merge.

Refs singi-labs/sifa-workspace#247.
