### PR TITLE
feat(course): add optional completedAt date to id.sifa.profile.course

### DIFF
--- a/lexicons/id/sifa/profile/course.json
+++ b/lexicons/id/sifa/profile/course.json
@@ -45,6 +45,11 @@
             "format": "at-uri",
             "description": "AT-URI of the associated id.sifa.profile.certification record (the credential earned from this course), if applicable. A plain at-uri rather than a strongRef so the link tracks the live certification across edits."
           },
+          "completedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Date the course was completed. Omit if unknown."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -329,6 +329,27 @@ describe.each([
   });
 });
 
+describe('Course completedAt field', () => {
+  const courseLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.course');
+  const properties = courseLexicon?.doc.defs.main.record?.properties;
+  const required = courseLexicon?.doc.defs.main.record?.required ?? [];
+
+  it('completedAt exists as an optional string with datetime format', () => {
+    expect(properties?.completedAt).toBeDefined();
+    expect(properties?.completedAt?.type).toBe('string');
+    expect(properties?.completedAt?.format).toBe('datetime');
+  });
+
+  it('completedAt is not required (many courses have no recorded date)', () => {
+    expect(required).not.toContain('completedAt');
+  });
+
+  it('completedAt has a description', () => {
+    expect(properties?.completedAt?.description).toBeDefined();
+    expect(properties?.completedAt?.description!.length).toBeGreaterThan(0);
+  });
+});
+
 describe('Publication subtitle field', () => {
   const publicationLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.publication');
   const properties = publicationLexicon?.doc.defs.main.record?.properties;


### PR DESCRIPTION
## Summary

Adds an optional `completedAt` date to the `id.sifa.profile.course` lexicon so a course can record when it was finished.

- `completedAt` is an optional `string` with `format: datetime`, matching the date convention used by `id.sifa.profile.certification` (`issuedAt`/`expiresAt`).
- Additive, backward-compatible change: existing course records without the field remain valid. Version bumped `0.9.1` -> `0.9.2` (PATCH, per this repo's additive convention).
- Tests cover the new field (optional, datetime format, described); the existing datetime-format guard also now asserts it.

Part of #254.
