### PR TITLE
feat(profile): relax five drifted date fields to freeform YYYY-MM

### DIFF
--- a/lexicons/id/sifa/profile/certification.json
+++ b/lexicons/id/sifa/profile/certification.json
@@ -47,13 +47,11 @@
           },
           "issuedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Date the certification was issued."
+            "description": "Date the certification was issued, in YYYY-MM or YYYY-MM-DD format."
           },
           "expiresAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Expiry date. Omit if the certification does not expire."
+            "description": "Expiry date in YYYY-MM or YYYY-MM-DD format. Omit if the certification does not expire."
           },
           "labels": {
             "type": "union",

--- a/lexicons/id/sifa/profile/course.json
+++ b/lexicons/id/sifa/profile/course.json
@@ -47,8 +47,7 @@
           },
           "completedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Date the course was completed. Omit if unknown."
+            "description": "Date the course was completed, in YYYY-MM or YYYY-MM-DD format. Omit if unknown."
           },
           "createdAt": {
             "type": "string",

--- a/lexicons/id/sifa/profile/honor.json
+++ b/lexicons/id/sifa/profile/honor.json
@@ -42,8 +42,7 @@
           },
           "awardedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Date the honor was awarded."
+            "description": "Date the honor was awarded, in YYYY-MM or YYYY-MM-DD format."
           },
           "createdAt": {
             "type": "string",

--- a/lexicons/id/sifa/profile/publication.json
+++ b/lexicons/id/sifa/profile/publication.json
@@ -52,8 +52,7 @@
           },
           "publishedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Publication date."
+            "description": "Publication date in YYYY-MM or YYYY-MM-DD format."
           },
           "createdAt": {
             "type": "string",

--- a/lexicons/id/sifa/profile/volunteering.json
+++ b/lexicons/id/sifa/profile/volunteering.json
@@ -48,13 +48,11 @@
           },
           "startedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "Start date of the volunteer role."
+            "description": "Start date of the volunteer role in YYYY-MM or YYYY-MM-DD format."
           },
           "endedAt": {
             "type": "string",
-            "format": "datetime",
-            "description": "End date. Omit if currently volunteering."
+            "description": "End date in YYYY-MM or YYYY-MM-DD format. Omit if currently volunteering."
           },
           "createdAt": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -203,6 +203,13 @@ const DATE_ONLY_FIELDS = new Set([
   'id.sifa.profile.project.endedAt',
   'id.sifa.profile.involvement.startedAt',
   'id.sifa.profile.involvement.endedAt',
+  'id.sifa.profile.volunteering.startedAt',
+  'id.sifa.profile.volunteering.endedAt',
+  'id.sifa.profile.certification.issuedAt',
+  'id.sifa.profile.certification.expiresAt',
+  'id.sifa.profile.course.completedAt',
+  'id.sifa.profile.honor.awardedAt',
+  'id.sifa.profile.publication.publishedAt',
 ]);
 
 describe('Timestamps use datetime format', () => {
@@ -334,10 +341,11 @@ describe('Course completedAt field', () => {
   const properties = courseLexicon?.doc.defs.main.record?.properties;
   const required = courseLexicon?.doc.defs.main.record?.required ?? [];
 
-  it('completedAt exists as an optional string with datetime format', () => {
+  it('completedAt is a freeform date string (no datetime format, YYYY-MM documented)', () => {
     expect(properties?.completedAt).toBeDefined();
     expect(properties?.completedAt?.type).toBe('string');
-    expect(properties?.completedAt?.format).toBe('datetime');
+    expect(properties?.completedAt?.format).toBeUndefined();
+    expect(properties?.completedAt?.description).toMatch(/YYYY-MM/);
   });
 
   it('completedAt is not required (many courses have no recorded date)', () => {
@@ -347,6 +355,27 @@ describe('Course completedAt field', () => {
   it('completedAt has a description', () => {
     expect(properties?.completedAt?.description).toBeDefined();
     expect(properties?.completedAt?.description!.length).toBeGreaterThan(0);
+  });
+});
+
+describe.each([
+  ['id.sifa.profile.volunteering', ['startedAt', 'endedAt']],
+  ['id.sifa.profile.certification', ['issuedAt', 'expiresAt']],
+  ['id.sifa.profile.honor', ['awardedAt']],
+  ['id.sifa.profile.publication', ['publishedAt']],
+] as const)('%s freeform date fields', (lexiconId, fields) => {
+  const lexicon = recordLexicons.find((l) => l.doc.id === lexiconId);
+  const properties = lexicon?.doc.defs.main.record?.properties;
+
+  it.each(fields)('%s is a freeform date string (no datetime format, YYYY-MM documented)', (f) => {
+    expect(properties?.[f]).toBeDefined();
+    expect(properties?.[f]?.type).toBe('string');
+    expect(properties?.[f]?.format).toBeUndefined();
+    expect(properties?.[f]?.description).toMatch(/YYYY-MM/);
+  });
+
+  it('createdAt still uses datetime format', () => {
+    expect(properties?.createdAt?.format).toBe('datetime');
   });
 });
 


### PR DESCRIPTION
Closes #256

Five profile lexicons required a strict `datetime` timestamp on their user-facing date fields, which rejected partial dates ("since 2018", year-only) and LinkedIn-importer writes. This relaxes them to freeform `YYYY-MM` / `YYYY-MM-DD` strings, matching the four sections that already do this right (position, project, education, involvement).

## Fields relaxed (dropped `format: datetime`, added YYYY-MM description)

- `id.sifa.profile.volunteering`: `startedAt`, `endedAt`
- `id.sifa.profile.certification`: `issuedAt`, `expiresAt`
- `id.sifa.profile.course`: `completedAt`
- `id.sifa.profile.honor`: `awardedAt`
- `id.sifa.profile.publication`: `publishedAt`

Record-metadata `createdAt` stays `datetime` everywhere.

## Tests

Added the five fields to `DATE_ONLY_FIELDS`, updated the course `completedAt` assertions, and added per-lexicon describes asserting the fields are freeform and `createdAt` stays datetime. 291 tests green. Lint, typecheck, and format clean.

Version bumped 0.9.2 to 0.9.3.

Pairs with the sifa-sdk PR loosening the matching Zod schemas.
