### PR TITLE
feat(lexicons): add org.profile and org.employmentAttestation lexicons (#160)

### DIFF
--- a/lexicons/id/sifa/org/employmentAttestation.json
+++ b/lexicons/id/sifa/org/employmentAttestation.json
@@ -1,0 +1,73 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.org.employmentAttestation",
+  "description": "An organization's attestation that a person is or was employed in a specific position. Lives in the organization's PDS; the organization is implicit (whoever owns the repository). The org asserts this person held the described role. The position identity is pinned via a snapshot triple (title, startedAt, and the entity identifier) so editing the pinned identity fields on the referenced position record voids this attestation. Never pins the free-text company name, which can change in a rebrand without invalidating the attestation.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing an organization's attestation of a person's employment.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "position", "status", "title", "startedAt", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the employee whose employment is being attested."
+          },
+          "position": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the id.sifa.profile.position record being attested. The AT-URI identifies the position, and the CID pins the version for provenance."
+          },
+          "status": {
+            "type": "string",
+            "description": "Whether the employment is current or past. Accepted values: 'current' or 'past'."
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxGraphemes": 256,
+            "maxLength": 2560,
+            "description": "Job title snapshot from the position record at attestation time. Part of the identity triple: if the position's title later changes, this attestation is voided (the role identity changed)."
+          },
+          "startedAt": {
+            "type": "string",
+            "description": "Start date snapshot in YYYY-MM or YYYY-MM-DD format, mirroring the position lexicon's freeform date shape. Part of the identity triple."
+          },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable entity identifier snapshot (Wikidata Q-ID URI, ROR URI, or LEI URI) from the position record. Pin this when the position carried an entityRef. Part of the identity triple. Never pin the free-text company name."
+          },
+          "companyDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the company's ATproto account snapshot from the position record. Pin this when the position carried a companyDid but no entityRef. Part of the identity triple."
+          },
+          "endedAt": {
+            "type": "string",
+            "description": "End date in YYYY-MM or YYYY-MM-DD format. Required context when status is 'past'."
+          },
+          "comment": {
+            "type": "string",
+            "maxGraphemes": 300,
+            "maxLength": 3000,
+            "description": "Optional brief comment from the organization."
+          },
+          "labels": {
+            "type": "union",
+            "description": "Self-label values for this attestation record.",
+            "refs": ["com.atproto.label.defs#selfLabels"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this attestation was created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/id/sifa/org/profile.json
+++ b/lexicons/id/sifa/org/profile.json
@@ -1,0 +1,65 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.org.profile",
+  "description": "Self-declared organization profile. Lives in the organization's PDS. Presence of this record marks the account as presenting as an organization; trust is layered separately by AppViews (Sifa's rendering floor, verification labels, registry matches). Creating this record asserts that the account holder is authorized to represent this organization. The assertion carries Terms-of-Service and legal weight but no trust weight on its own. Independently evaluable by any AppView with zero Sifa dependency.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "The organization's self-declared profile. Singleton: one org declaration per DID, following the app.bsky.actor.profile pattern.",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": ["name", "createdAt"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxGraphemes": 200,
+            "maxLength": 2000,
+            "description": "Organization display name."
+          },
+          "description": {
+            "type": "string",
+            "maxGraphemes": 5000,
+            "maxLength": 50000,
+            "description": "Organization description / about."
+          },
+          "logo": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg"],
+            "maxSize": 1000000,
+            "description": "Organization logo image."
+          },
+          "website": {
+            "type": "string",
+            "format": "uri",
+            "description": "Official website URL."
+          },
+          "entityRefs": {
+            "type": "array",
+            "maxLength": 20,
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
+            "description": "Canonical external entity identifiers this account represents: Wikidata Q-ID URIs (http://www.wikidata.org/entity/Q...), ROR URIs, or LEI URIs. Self-declared; downstream validation (registry match) confirms or fails each binding."
+          },
+          "contact": {
+            "type": "string",
+            "description": "Contact email address for the organization. NOT rendered publicly; used for notifications only. Validated as an email address at the app layer."
+          },
+          "labels": {
+            "type": "union",
+            "description": "Self-label values for this organization profile.",
+            "refs": ["com.atproto.label.defs#selfLabels"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this organization profile was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.9.1",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -159,7 +159,16 @@ describe('Record key conventions', () => {
     expect(selfLexicon!.doc.defs.main.key).toBe('literal:self');
   });
 
-  it.each(recordLexicons.filter((l) => l.doc.id !== 'id.sifa.profile.self').map((l) => [l.doc.id]))(
+  it('id.sifa.org.profile uses "literal:self" key (singleton)', () => {
+    const orgLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.org.profile');
+    expect(orgLexicon).toBeDefined();
+    expect(orgLexicon!.doc.defs.main.key).toBe('literal:self');
+  });
+
+  // Singleton records (literal:self) are excluded from the tid-key check.
+  const SINGLETON_LEXICONS = new Set(['id.sifa.profile.self', 'id.sifa.org.profile']);
+
+  it.each(recordLexicons.filter((l) => !SINGLETON_LEXICONS.has(l.doc.id)).map((l) => [l.doc.id]))(
     '%s uses "tid" key (collection)',
     (nsid) => {
       const lexicon = recordLexicons.find((l) => l.doc.id === nsid);
@@ -210,6 +219,8 @@ const DATE_ONLY_FIELDS = new Set([
   'id.sifa.profile.course.completedAt',
   'id.sifa.profile.honor.awardedAt',
   'id.sifa.profile.publication.publishedAt',
+  'id.sifa.org.employmentAttestation.startedAt',
+  'id.sifa.org.employmentAttestation.endedAt',
 ]);
 
 describe('Timestamps use datetime format', () => {


### PR DESCRIPTION
Adds two organization lexicons for the #160 org-trust milestone.

id.sifa.org.profile: self-declared org record (literal:self singleton). One org declaration per DID. Required name and createdAt; optional description, logo, website, entityRefs (Wikidata/ROR/LEI URIs), contact (email, not public). Creating the record asserts authority to represent the organization.

id.sifa.org.employmentAttestation: org-issued attestation (tid key). Pins identity via strongRef to the position record plus a snapshot triple (title, startedAt, entityRef or companyDid). Status current or past. Editing the pinned identity fields on the position voids the attestation.

DRAFT: held for review/publish window. The conductor/Guido hold the publish.
