### PR TITLE
feat(lexicons): add id.sifa.getProfileView query method

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Every schema in this repo is published as a `com.atproto.lexicon.schema` record 
 | `id.sifa.authConnection`    | Connection management                  |
 | `id.sifa.authProject`       | Project creation and team management   |
 
+**Query methods**
+
+| NSID                     | Purpose                                           |
+| ------------------------ | ------------------------------------------------- |
+| `id.sifa.getProfileView` | Aggregated public profile view served by AppViews |
+
 **Shared types**
 
 | NSID           | Purpose                 |

--- a/lexicons/id/sifa/getProfileView.json
+++ b/lexicons/id/sifa/getProfileView.json
@@ -1,0 +1,806 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.getProfileView",
+  "description": "Get the aggregated public professional profile for an actor, as computed by a Sifa AppView. This view joins a user's id.sifa.* records across all sections (positions, education, skills, endorsements received, and more) plus AppView-computed aggregates (follower/connection counts, active apps, verification state). Raw records remain readable directly from the user's PDS; this method exposes the enriched, joined view that only exists in the AppView. Public projection: viewer-specific and internal fields are not included.",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get the aggregated public profile view for an actor.",
+      "parameters": {
+        "type": "params",
+        "required": ["actor"],
+        "properties": {
+          "actor": {
+            "type": "string",
+            "format": "at-identifier",
+            "description": "The handle or DID of the profile to fetch."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "#profileView"
+        }
+      },
+      "errors": [
+        {
+          "name": "ProfileNotFound",
+          "description": "No profile exists for the given actor, or the actor could not be resolved."
+        }
+      ]
+    },
+
+    "profileView": {
+      "type": "object",
+      "description": "The aggregated public professional profile view.",
+      "required": ["did", "handle"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "The account DID. Stable identifier for the profile."
+        },
+        "handle": {
+          "type": "string",
+          "format": "handle",
+          "description": "The current handle for the account."
+        },
+        "displayName": {
+          "type": "string",
+          "maxGraphemes": 128,
+          "maxLength": 1280,
+          "description": "Display name shown on the profile."
+        },
+        "givenName": {
+          "type": "string",
+          "maxGraphemes": 128,
+          "maxLength": 1280,
+          "description": "Given (first) name, when provided."
+        },
+        "familyName": {
+          "type": "string",
+          "maxGraphemes": 128,
+          "maxLength": 1280,
+          "description": "Family (last) name, when provided."
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the profile avatar image."
+        },
+        "pronouns": {
+          "type": "string",
+          "maxGraphemes": 64,
+          "maxLength": 640,
+          "description": "Self-described pronouns."
+        },
+        "headline": {
+          "type": "string",
+          "maxGraphemes": 300,
+          "maxLength": 3000,
+          "description": "Short professional headline."
+        },
+        "about": {
+          "type": "string",
+          "maxGraphemes": 5000,
+          "maxLength": 50000,
+          "description": "Longer professional summary or bio."
+        },
+        "industries": {
+          "type": "array",
+          "description": "Industry/domain pairs the user works in.",
+          "items": { "type": "ref", "ref": "id.sifa.defs#industryDomain" }
+        },
+        "locationCountry": {
+          "type": "string",
+          "description": "Primary location country name."
+        },
+        "locationRegion": {
+          "type": "string",
+          "description": "Primary location region, state, or province."
+        },
+        "locationLocality": {
+          "type": "string",
+          "description": "Primary location city or locality."
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 alpha-2 country code for the primary location."
+        },
+        "location": {
+          "type": "string",
+          "description": "Assembled human-readable primary location string."
+        },
+        "locations": {
+          "type": "array",
+          "description": "All professional locations on the profile.",
+          "items": { "type": "ref", "ref": "#locationView" }
+        },
+        "website": {
+          "type": "string",
+          "format": "uri",
+          "description": "Primary personal or professional website."
+        },
+        "openTo": {
+          "type": "array",
+          "description": "The kinds of opportunities the user is open to.",
+          "items": { "type": "ref", "ref": "id.sifa.defs#openToWorkStatus" }
+        },
+        "preferredWorkplace": {
+          "type": "ref",
+          "ref": "id.sifa.defs#workplaceType",
+          "description": "Preferred workplace arrangement."
+        },
+        "availableFromUtc": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Start of an availability window, if set."
+        },
+        "availableToUtc": {
+          "type": "string",
+          "format": "datetime",
+          "description": "End of an availability window, if set."
+        },
+        "langs": {
+          "type": "array",
+          "description": "BCP-47 language tags the user has indicated.",
+          "items": { "type": "string", "format": "language" }
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the profile record was created."
+        },
+        "positions": {
+          "type": "array",
+          "description": "Work history entries.",
+          "items": { "type": "ref", "ref": "#positionView" }
+        },
+        "education": {
+          "type": "array",
+          "description": "Education history entries.",
+          "items": { "type": "ref", "ref": "#educationView" }
+        },
+        "skills": {
+          "type": "array",
+          "description": "Skills, optionally linked to positions.",
+          "items": { "type": "ref", "ref": "#skillView" }
+        },
+        "certifications": {
+          "type": "array",
+          "description": "Certifications and licenses.",
+          "items": { "type": "ref", "ref": "#certificationView" }
+        },
+        "projects": {
+          "type": "array",
+          "description": "Personal or professional projects.",
+          "items": { "type": "ref", "ref": "#projectView" }
+        },
+        "volunteering": {
+          "type": "array",
+          "description": "Legacy volunteering entries. New entries are surfaced under involvement.",
+          "items": { "type": "ref", "ref": "#volunteeringView" }
+        },
+        "involvement": {
+          "type": "array",
+          "description": "Community, open-source, charity, and civic involvement.",
+          "items": { "type": "ref", "ref": "#involvementView" }
+        },
+        "publications": {
+          "type": "array",
+          "description": "Publications, merged from Sifa records and linked ORCID works.",
+          "items": { "type": "ref", "ref": "#publicationView" }
+        },
+        "courses": {
+          "type": "array",
+          "description": "Courses, optionally linked to a credential.",
+          "items": { "type": "ref", "ref": "#courseView" }
+        },
+        "presentations": {
+          "type": "array",
+          "description": "Talks and sessions (content), each with its deliveries grouped underneath.",
+          "items": { "type": "ref", "ref": "#presentationView" }
+        },
+        "presentationDeliveries": {
+          "type": "array",
+          "description": "Standalone deliveries that reference no owned presentation.",
+          "items": { "type": "ref", "ref": "#presentationDeliveryView" }
+        },
+        "honors": {
+          "type": "array",
+          "description": "Honors and awards.",
+          "items": { "type": "ref", "ref": "#honorView" }
+        },
+        "languages": {
+          "type": "array",
+          "description": "Spoken/written languages with proficiency.",
+          "items": { "type": "ref", "ref": "#languageView" }
+        },
+        "externalAccounts": {
+          "type": "array",
+          "description": "Linked external accounts, with verification state.",
+          "items": { "type": "ref", "ref": "#externalAccountView" }
+        },
+        "atfundContribute": {
+          "type": "ref",
+          "ref": "#atfundLink",
+          "description": "Optional contribution/funding link."
+        },
+        "followersCount": {
+          "type": "integer",
+          "description": "Number of Sifa graph followers."
+        },
+        "followingCount": {
+          "type": "integer",
+          "description": "Number of accounts this profile follows on the Sifa graph."
+        },
+        "connectionsCount": {
+          "type": "integer",
+          "description": "Number of confirmed professional connections."
+        },
+        "metInPersonCount": {
+          "type": "integer",
+          "description": "Number of confirmed in-person meetings."
+        },
+        "atprotoFollowersCount": {
+          "type": "integer",
+          "description": "Number of app.bsky.graph followers."
+        },
+        "blueskyVerified": {
+          "type": "boolean",
+          "description": "Whether the account holds a Bluesky verification."
+        },
+        "blueskyVerifiedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the Bluesky verification was issued."
+        },
+        "activeApps": {
+          "type": "array",
+          "description": "AT Protocol apps this account has recently created records in.",
+          "items": { "type": "ref", "ref": "#activeAppView" }
+        },
+        "pdsProvider": {
+          "type": "string",
+          "description": "Human-readable name of the account's PDS provider."
+        },
+        "claimed": {
+          "type": "boolean",
+          "description": "Whether the profile has been claimed by its owner on Sifa."
+        }
+      }
+    },
+
+    "locationView": {
+      "type": "object",
+      "description": "A professional location on the profile.",
+      "required": ["rkey"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the location record." },
+        "type": {
+          "type": "ref",
+          "ref": "id.sifa.defs#locationType",
+          "description": "The role this location plays."
+        },
+        "label": { "type": "string", "description": "Optional custom label." },
+        "isPrimary": { "type": "boolean", "description": "Whether this is the primary location." },
+        "locationCountry": { "type": "string", "description": "Country name." },
+        "locationRegion": { "type": "string", "description": "Region, state, or province." },
+        "locationLocality": { "type": "string", "description": "City or locality." },
+        "countryCode": { "type": "string", "description": "ISO 3166-1 alpha-2 country code." },
+        "location": { "type": "string", "description": "Assembled human-readable location string." }
+      }
+    },
+
+    "positionView": {
+      "type": "object",
+      "description": "A work-history entry.",
+      "required": ["rkey", "title"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the position record." },
+        "title": { "type": "string", "description": "Job title or role." },
+        "company": { "type": "string", "description": "Company or organization name." },
+        "companyDid": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the company, when known."
+        },
+        "entityRef": {
+          "type": "string",
+          "format": "uri",
+          "description": "Pointer URI to the resolved company entity."
+        },
+        "entityName": { "type": "string", "description": "Resolved canonical company name." },
+        "description": { "type": "string", "description": "Role description." },
+        "employmentType": {
+          "type": "ref",
+          "ref": "id.sifa.defs#employmentType",
+          "description": "Employment arrangement."
+        },
+        "workplaceType": {
+          "type": "ref",
+          "ref": "id.sifa.defs#workplaceType",
+          "description": "Workplace arrangement."
+        },
+        "locationCountry": { "type": "string", "description": "Country name." },
+        "locationRegion": { "type": "string", "description": "Region, state, or province." },
+        "locationLocality": { "type": "string", "description": "City or locality." },
+        "countryCode": { "type": "string", "description": "ISO 3166-1 alpha-2 country code." },
+        "location": {
+          "type": "string",
+          "description": "Assembled human-readable location string."
+        },
+        "startedAt": {
+          "type": "string",
+          "description": "Start date. Partial date (YYYY, YYYY-MM, or YYYY-MM-DD)."
+        },
+        "endedAt": {
+          "type": "string",
+          "description": "End date. Partial date, absent if current."
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Whether this is the user's primary current position."
+        },
+        "skillRkeys": {
+          "type": "array",
+          "description": "Record keys of skills linked to this position.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "educationView": {
+      "type": "object",
+      "description": "An education-history entry.",
+      "required": ["rkey"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the education record." },
+        "institution": { "type": "string", "description": "Institution name." },
+        "institutionDid": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the institution, when known."
+        },
+        "entityRef": {
+          "type": "string",
+          "format": "uri",
+          "description": "Pointer URI to the resolved institution entity."
+        },
+        "degree": { "type": "string", "description": "Degree earned." },
+        "fieldOfStudy": { "type": "string", "description": "Field of study." },
+        "activities": { "type": "string", "description": "Activities and societies." },
+        "description": { "type": "string", "description": "Additional description." },
+        "startedAt": { "type": "string", "description": "Start date. Partial date." },
+        "endedAt": { "type": "string", "description": "End date. Partial date." }
+      }
+    },
+
+    "skillView": {
+      "type": "object",
+      "description": "A skill entry.",
+      "required": ["rkey", "name"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the skill record." },
+        "name": { "type": "string", "description": "Skill name." },
+        "category": {
+          "type": "ref",
+          "ref": "id.sifa.defs#skillCategory",
+          "description": "Broad category."
+        },
+        "positionRkeys": {
+          "type": "array",
+          "description": "Record keys of positions this skill is linked to.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "certificationView": {
+      "type": "object",
+      "description": "A certification or license.",
+      "required": ["rkey", "name"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the certification record." },
+        "name": { "type": "string", "description": "Certification name." },
+        "issuingOrg": { "type": "string", "description": "Issuing organization." },
+        "entityRef": {
+          "type": "string",
+          "format": "uri",
+          "description": "Pointer URI to the resolved issuer entity."
+        },
+        "issueDate": { "type": "string", "description": "Issue date. Partial date." },
+        "expiryDate": { "type": "string", "description": "Expiry date. Partial date." },
+        "credentialUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the credential."
+        }
+      }
+    },
+
+    "projectView": {
+      "type": "object",
+      "description": "A project entry.",
+      "required": ["rkey", "name"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the project record." },
+        "name": { "type": "string", "description": "Project name." },
+        "description": { "type": "string", "description": "Project description." },
+        "url": { "type": "string", "format": "uri", "description": "Project URL." },
+        "startDate": { "type": "string", "description": "Start date. Partial date." },
+        "endDate": { "type": "string", "description": "End date. Partial date." }
+      }
+    },
+
+    "volunteeringView": {
+      "type": "object",
+      "description": "A legacy volunteering entry.",
+      "required": ["rkey", "organization"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the volunteering record." },
+        "organization": { "type": "string", "description": "Organization name." },
+        "entityRef": {
+          "type": "string",
+          "format": "uri",
+          "description": "Pointer URI to the resolved organization entity."
+        },
+        "role": { "type": "string", "description": "Role held." },
+        "cause": { "type": "string", "description": "Cause supported." },
+        "description": { "type": "string", "description": "Description." },
+        "startDate": { "type": "string", "description": "Start date. Partial date." },
+        "endDate": { "type": "string", "description": "End date. Partial date." }
+      }
+    },
+
+    "involvementView": {
+      "type": "object",
+      "description": "A community, open-source, charity, or civic involvement.",
+      "required": ["rkey", "kind", "links", "legacy"],
+      "properties": {
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the involvement (or legacy volunteering) record."
+        },
+        "kind": {
+          "type": "ref",
+          "ref": "id.sifa.defs#involvementKind",
+          "description": "The nature of the involvement."
+        },
+        "upstream": {
+          "type": "string",
+          "description": "Name of the community, org, or person the involvement is with."
+        },
+        "upstreamDid": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the upstream, when known."
+        },
+        "upstreamUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the upstream, when provided."
+        },
+        "role": { "type": "string", "description": "Role in the involvement." },
+        "description": { "type": "string", "description": "Description." },
+        "startedAt": { "type": "string", "description": "Start date. Partial date." },
+        "endedAt": { "type": "string", "description": "End date. Partial date." },
+        "links": {
+          "type": "array",
+          "description": "Public artifact links proving the work.",
+          "items": { "type": "ref", "ref": "#involvementLinkView" }
+        },
+        "legacy": {
+          "type": "boolean",
+          "description": "True if mapped from a legacy volunteering record."
+        }
+      }
+    },
+
+    "involvementLinkView": {
+      "type": "object",
+      "description": "A proof link on an involvement.",
+      "required": ["url"],
+      "properties": {
+        "url": { "type": "string", "format": "uri", "description": "Artifact URL." },
+        "kind": {
+          "type": "string",
+          "description": "What the link points to (e.g. pull-request, talk, article)."
+        },
+        "label": { "type": "string", "description": "Optional human-readable label." },
+        "verified": {
+          "type": "boolean",
+          "description": "True if the link host matches a verified external account."
+        },
+        "verifiedPlatform": {
+          "type": "string",
+          "description": "Platform token of the verified host, when verified."
+        }
+      }
+    },
+
+    "publicationView": {
+      "type": "object",
+      "description": "A publication, merged from Sifa and linked ORCID works.",
+      "required": ["rkey", "title", "verified"],
+      "properties": {
+        "rkey": {
+          "type": "string",
+          "description": "Record key, or a synthetic key for ORCID-only works."
+        },
+        "title": { "type": "string", "description": "Publication title." },
+        "subtitle": { "type": "string", "description": "Subtitle." },
+        "publisher": { "type": "string", "description": "Publisher or journal." },
+        "date": { "type": "string", "description": "Publication date. Partial date." },
+        "url": { "type": "string", "format": "uri", "description": "Publication URL." },
+        "description": { "type": "string", "description": "Description or abstract." },
+        "doi": { "type": "string", "description": "Digital Object Identifier." },
+        "type": { "type": "string", "description": "Publication type token." },
+        "typeLabel": { "type": "string", "description": "Human-readable publication type." },
+        "contributors": {
+          "type": "array",
+          "description": "Linked contributors (co-authors).",
+          "items": { "type": "ref", "ref": "#contributorView" }
+        },
+        "verified": {
+          "type": "boolean",
+          "description": "Whether the publication is verified (e.g. via ORCID)."
+        },
+        "verifiedVia": { "type": "string", "description": "Verification source, when verified." },
+        "orcidCorroborated": {
+          "type": "boolean",
+          "description": "Whether an ORCID work corroborates a Sifa record."
+        },
+        "publicationUri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of the source publication record, when present."
+        },
+        "publicationUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical publication URL, when present."
+        },
+        "publicationName": {
+          "type": "string",
+          "description": "Name of the source publication venue, when present."
+        },
+        "image": { "type": "string", "format": "uri", "description": "Cover or preview image URL." }
+      }
+    },
+
+    "contributorView": {
+      "type": "object",
+      "description": "A linked publication contributor.",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "description": "Contributor name." },
+        "orcidId": { "type": "string", "description": "ORCID identifier." },
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "Sifa/AT Protocol DID, when linked."
+        },
+        "handle": { "type": "string", "format": "handle", "description": "Handle, when linked." }
+      }
+    },
+
+    "courseView": {
+      "type": "object",
+      "description": "A course entry.",
+      "required": ["rkey", "name"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the course record." },
+        "name": { "type": "string", "description": "Course name." },
+        "number": { "type": "string", "description": "Course number or code." },
+        "institution": { "type": "string", "description": "Institution name." },
+        "entityRef": {
+          "type": "string",
+          "format": "uri",
+          "description": "Pointer URI to the resolved institution entity."
+        },
+        "credentialRkey": {
+          "type": "string",
+          "description": "Record key of a linked certification, when present."
+        }
+      }
+    },
+
+    "presentationView": {
+      "type": "object",
+      "description": "A talk or session (content), with its deliveries grouped underneath.",
+      "required": ["rkey", "title", "deliveries"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the presentation record." },
+        "title": { "type": "string", "description": "Presentation title." },
+        "description": { "type": "string", "description": "Presentation description." },
+        "duration": {
+          "type": "ref",
+          "ref": "#durationView",
+          "description": "Duration range in minutes."
+        },
+        "intendedAudiences": {
+          "type": "array",
+          "description": "Intended audiences.",
+          "items": { "type": "string" }
+        },
+        "links": {
+          "type": "array",
+          "description": "Related links (slides, recording, etc.).",
+          "items": { "type": "ref", "ref": "id.sifa.defs#presentationLink" }
+        },
+        "writeupUri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of a linked write-up record."
+        },
+        "deliveries": {
+          "type": "array",
+          "description": "Deliveries of this presentation.",
+          "items": { "type": "ref", "ref": "#presentationDeliveryView" }
+        }
+      }
+    },
+
+    "durationView": {
+      "type": "object",
+      "description": "A duration range in minutes.",
+      "required": ["minMinutes"],
+      "properties": {
+        "minMinutes": { "type": "integer", "description": "Minimum duration in minutes." },
+        "maxMinutes": { "type": "integer", "description": "Maximum duration in minutes." }
+      }
+    },
+
+    "presentationDeliveryView": {
+      "type": "object",
+      "description": "A single delivery of a presentation at an occasion.",
+      "required": ["rkey"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the delivery record." },
+        "presentationRkey": {
+          "type": "string",
+          "description": "Record key of the parent presentation, when grouped."
+        },
+        "title": {
+          "type": "string",
+          "description": "Delivery title (may differ from the presentation title)."
+        },
+        "role": {
+          "type": "ref",
+          "ref": "id.sifa.defs#presentationRole",
+          "description": "The user's role in the delivery."
+        },
+        "eventName": { "type": "string", "description": "Name of the event or occasion." },
+        "date": { "type": "string", "description": "Delivery date. Partial date." },
+        "location": { "type": "string", "description": "Event location." },
+        "mode": {
+          "type": "string",
+          "description": "Delivery mode (e.g. in-person, remote, hybrid)."
+        },
+        "status": { "type": "string", "description": "Delivery status." },
+        "links": {
+          "type": "array",
+          "description": "Related links for this delivery.",
+          "items": { "type": "ref", "ref": "id.sifa.defs#presentationLink" }
+        },
+        "eventUri": {
+          "type": "string",
+          "format": "at-uri",
+          "description": "AT-URI of a linked event record."
+        },
+        "coSpeakers": {
+          "type": "array",
+          "description": "Co-speakers on this delivery.",
+          "items": { "type": "ref", "ref": "#coSpeakerView" }
+        }
+      }
+    },
+
+    "coSpeakerView": {
+      "type": "object",
+      "description": "A co-speaker on a presentation delivery.",
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the co-speaker, when linked to a Sifa profile."
+        },
+        "handle": { "type": "string", "format": "handle", "description": "Handle, when linked." },
+        "displayName": { "type": "string", "description": "Display name, when linked." },
+        "avatar": { "type": "string", "format": "uri", "description": "Avatar URL, when linked." },
+        "name": { "type": "string", "description": "Free-text co-speaker name, when not linked." }
+      }
+    },
+
+    "honorView": {
+      "type": "object",
+      "description": "An honor or award.",
+      "required": ["rkey", "title"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the honor record." },
+        "title": { "type": "string", "description": "Honor or award title." },
+        "issuer": { "type": "string", "description": "Issuing organization." },
+        "entityRef": {
+          "type": "string",
+          "format": "uri",
+          "description": "Pointer URI to the resolved issuer entity."
+        },
+        "description": { "type": "string", "description": "Description." },
+        "date": { "type": "string", "description": "Date received. Partial date." }
+      }
+    },
+
+    "languageView": {
+      "type": "object",
+      "description": "A language with proficiency.",
+      "required": ["rkey", "language"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the language record." },
+        "language": { "type": "string", "description": "Language name or BCP-47 tag." },
+        "proficiency": {
+          "type": "ref",
+          "ref": "id.sifa.defs#proficiency",
+          "description": "Proficiency level."
+        }
+      }
+    },
+
+    "externalAccountView": {
+      "type": "object",
+      "description": "A linked external account with verification state.",
+      "required": ["rkey", "url"],
+      "properties": {
+        "rkey": { "type": "string", "description": "Record key of the external account record." },
+        "platform": {
+          "type": "ref",
+          "ref": "id.sifa.defs#externalPlatform",
+          "description": "Platform type."
+        },
+        "url": { "type": "string", "format": "uri", "description": "Account URL." },
+        "label": { "type": "string", "description": "Optional custom label." },
+        "feedUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Feed URL (RSS/Atom), when applicable."
+        },
+        "verifiable": { "type": "boolean", "description": "Whether the account can be verified." },
+        "verified": { "type": "boolean", "description": "Whether the account is verified." },
+        "verifiedVia": { "type": "string", "description": "Verification method, when verified." },
+        "primary": {
+          "type": "boolean",
+          "description": "Whether this is the primary external account."
+        }
+      }
+    },
+
+    "activeAppView": {
+      "type": "object",
+      "description": "An AT Protocol app the account has recently created records in.",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "description": "App identifier." },
+        "name": { "type": "string", "description": "App display name." },
+        "category": { "type": "string", "description": "App category." },
+        "recentCount": { "type": "integer", "description": "Recent record count." },
+        "latestRecordAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the latest record."
+        }
+      }
+    },
+
+    "atfundLink": {
+      "type": "object",
+      "description": "A contribution or funding link.",
+      "required": ["url"],
+      "properties": {
+        "url": { "type": "string", "format": "uri", "description": "Contribution URL." },
+        "label": { "type": "string", "description": "Optional display label." }
+      }
+    }
+  }
+}

--- a/lexicons/id/sifa/getProfileView.json
+++ b/lexicons/id/sifa/getProfileView.json
@@ -319,8 +319,9 @@
           }
         },
         "pdsProvider": {
-          "type": "string",
-          "description": "Human-readable name of the account's PDS provider."
+          "type": "ref",
+          "ref": "#pdsProviderView",
+          "description": "The account PDS provider."
         },
         "claimed": {
           "type": "boolean",
@@ -1173,6 +1174,21 @@
         "label": {
           "type": "string",
           "description": "Optional display label."
+        }
+      }
+    },
+    "pdsProviderView": {
+      "type": "object",
+      "description": "A PDS provider descriptor.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable provider name."
+        },
+        "host": {
+          "type": "string",
+          "description": "PDS hostname."
         }
       }
     }

--- a/lexicons/id/sifa/getProfileView.json
+++ b/lexicons/id/sifa/getProfileView.json
@@ -31,7 +31,6 @@
         }
       ]
     },
-
     "profileView": {
       "type": "object",
       "description": "The aggregated public professional profile view.",
@@ -91,7 +90,10 @@
         "industries": {
           "type": "array",
           "description": "Industry/domain pairs the user works in.",
-          "items": { "type": "ref", "ref": "id.sifa.defs#industryDomain" }
+          "items": {
+            "type": "ref",
+            "ref": "id.sifa.defs#industryDomain"
+          }
         },
         "locationCountry": {
           "type": "string",
@@ -116,7 +118,10 @@
         "locations": {
           "type": "array",
           "description": "All professional locations on the profile.",
-          "items": { "type": "ref", "ref": "#locationView" }
+          "items": {
+            "type": "ref",
+            "ref": "#locationView"
+          }
         },
         "website": {
           "type": "string",
@@ -126,27 +131,33 @@
         "openTo": {
           "type": "array",
           "description": "The kinds of opportunities the user is open to.",
-          "items": { "type": "ref", "ref": "id.sifa.defs#openToWorkStatus" }
+          "items": {
+            "type": "ref",
+            "ref": "id.sifa.defs#openToWorkStatus"
+          }
         },
         "preferredWorkplace": {
-          "type": "ref",
-          "ref": "id.sifa.defs#workplaceType",
-          "description": "Preferred workplace arrangement."
+          "type": "array",
+          "description": "Preferred workplace arrangements.",
+          "items": {
+            "type": "ref",
+            "ref": "id.sifa.defs#workplaceType"
+          }
         },
         "availableFromUtc": {
-          "type": "string",
-          "format": "datetime",
-          "description": "Start of an availability window, if set."
+          "type": "integer",
+          "description": "Start of an availability window, as a UTC offset, if set."
         },
         "availableToUtc": {
-          "type": "string",
-          "format": "datetime",
-          "description": "End of an availability window, if set."
+          "type": "integer",
+          "description": "End of an availability window, as a UTC offset, if set."
         },
         "langs": {
           "type": "array",
           "description": "BCP-47 language tags the user has indicated.",
-          "items": { "type": "string", "format": "language" }
+          "items": {
+            "type": "string"
+          }
         },
         "createdAt": {
           "type": "string",
@@ -156,72 +167,114 @@
         "positions": {
           "type": "array",
           "description": "Work history entries.",
-          "items": { "type": "ref", "ref": "#positionView" }
+          "items": {
+            "type": "ref",
+            "ref": "#positionView"
+          }
         },
         "education": {
           "type": "array",
           "description": "Education history entries.",
-          "items": { "type": "ref", "ref": "#educationView" }
+          "items": {
+            "type": "ref",
+            "ref": "#educationView"
+          }
         },
         "skills": {
           "type": "array",
           "description": "Skills, optionally linked to positions.",
-          "items": { "type": "ref", "ref": "#skillView" }
+          "items": {
+            "type": "ref",
+            "ref": "#skillView"
+          }
         },
         "certifications": {
           "type": "array",
           "description": "Certifications and licenses.",
-          "items": { "type": "ref", "ref": "#certificationView" }
+          "items": {
+            "type": "ref",
+            "ref": "#certificationView"
+          }
         },
         "projects": {
           "type": "array",
           "description": "Personal or professional projects.",
-          "items": { "type": "ref", "ref": "#projectView" }
+          "items": {
+            "type": "ref",
+            "ref": "#projectView"
+          }
         },
         "volunteering": {
           "type": "array",
           "description": "Legacy volunteering entries. New entries are surfaced under involvement.",
-          "items": { "type": "ref", "ref": "#volunteeringView" }
+          "items": {
+            "type": "ref",
+            "ref": "#volunteeringView"
+          }
         },
         "involvement": {
           "type": "array",
           "description": "Community, open-source, charity, and civic involvement.",
-          "items": { "type": "ref", "ref": "#involvementView" }
+          "items": {
+            "type": "ref",
+            "ref": "#involvementView"
+          }
         },
         "publications": {
           "type": "array",
           "description": "Publications, merged from Sifa records and linked ORCID works.",
-          "items": { "type": "ref", "ref": "#publicationView" }
+          "items": {
+            "type": "ref",
+            "ref": "#publicationView"
+          }
         },
         "courses": {
           "type": "array",
           "description": "Courses, optionally linked to a credential.",
-          "items": { "type": "ref", "ref": "#courseView" }
+          "items": {
+            "type": "ref",
+            "ref": "#courseView"
+          }
         },
         "presentations": {
           "type": "array",
           "description": "Talks and sessions (content), each with its deliveries grouped underneath.",
-          "items": { "type": "ref", "ref": "#presentationView" }
+          "items": {
+            "type": "ref",
+            "ref": "#presentationView"
+          }
         },
         "presentationDeliveries": {
           "type": "array",
           "description": "Standalone deliveries that reference no owned presentation.",
-          "items": { "type": "ref", "ref": "#presentationDeliveryView" }
+          "items": {
+            "type": "ref",
+            "ref": "#presentationDeliveryView"
+          }
         },
         "honors": {
           "type": "array",
           "description": "Honors and awards.",
-          "items": { "type": "ref", "ref": "#honorView" }
+          "items": {
+            "type": "ref",
+            "ref": "#honorView"
+          }
         },
         "languages": {
           "type": "array",
           "description": "Spoken/written languages with proficiency.",
-          "items": { "type": "ref", "ref": "#languageView" }
+          "items": {
+            "type": "ref",
+            "ref": "#languageView"
+          }
         },
         "externalAccounts": {
           "type": "array",
           "description": "Linked external accounts, with verification state.",
-          "items": { "type": "ref", "ref": "#externalAccountView" }
+          "items": {
+            "type": "ref",
+            "ref": "#externalAccountView"
+          }
         },
         "atfundContribute": {
           "type": "ref",
@@ -260,7 +313,10 @@
         "activeApps": {
           "type": "array",
           "description": "AT Protocol apps this account has recently created records in.",
-          "items": { "type": "ref", "ref": "#activeAppView" }
+          "items": {
+            "type": "ref",
+            "ref": "#activeAppView"
+          }
         },
         "pdsProvider": {
           "type": "string",
@@ -272,36 +328,67 @@
         }
       }
     },
-
     "locationView": {
       "type": "object",
       "description": "A professional location on the profile.",
       "required": ["rkey"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the location record." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the location record."
+        },
         "type": {
           "type": "ref",
           "ref": "id.sifa.defs#locationType",
           "description": "The role this location plays."
         },
-        "label": { "type": "string", "description": "Optional custom label." },
-        "isPrimary": { "type": "boolean", "description": "Whether this is the primary location." },
-        "locationCountry": { "type": "string", "description": "Country name." },
-        "locationRegion": { "type": "string", "description": "Region, state, or province." },
-        "locationLocality": { "type": "string", "description": "City or locality." },
-        "countryCode": { "type": "string", "description": "ISO 3166-1 alpha-2 country code." },
-        "location": { "type": "string", "description": "Assembled human-readable location string." }
+        "label": {
+          "type": "string",
+          "description": "Optional custom label."
+        },
+        "isPrimary": {
+          "type": "boolean",
+          "description": "Whether this is the primary location."
+        },
+        "locationCountry": {
+          "type": "string",
+          "description": "Country name."
+        },
+        "locationRegion": {
+          "type": "string",
+          "description": "Region, state, or province."
+        },
+        "locationLocality": {
+          "type": "string",
+          "description": "City or locality."
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 alpha-2 country code."
+        },
+        "location": {
+          "type": "string",
+          "description": "Assembled human-readable location string."
+        }
       }
     },
-
     "positionView": {
       "type": "object",
       "description": "A work-history entry.",
       "required": ["rkey", "title"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the position record." },
-        "title": { "type": "string", "description": "Job title or role." },
-        "company": { "type": "string", "description": "Company or organization name." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the position record."
+        },
+        "title": {
+          "type": "string",
+          "description": "Job title or role."
+        },
+        "company": {
+          "type": "string",
+          "description": "Company or organization name."
+        },
         "companyDid": {
           "type": "string",
           "format": "did",
@@ -312,8 +399,14 @@
           "format": "uri",
           "description": "Pointer URI to the resolved company entity."
         },
-        "entityName": { "type": "string", "description": "Resolved canonical company name." },
-        "description": { "type": "string", "description": "Role description." },
+        "entityName": {
+          "type": "string",
+          "description": "Resolved canonical company name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Role description."
+        },
         "employmentType": {
           "type": "ref",
           "ref": "id.sifa.defs#employmentType",
@@ -324,10 +417,22 @@
           "ref": "id.sifa.defs#workplaceType",
           "description": "Workplace arrangement."
         },
-        "locationCountry": { "type": "string", "description": "Country name." },
-        "locationRegion": { "type": "string", "description": "Region, state, or province." },
-        "locationLocality": { "type": "string", "description": "City or locality." },
-        "countryCode": { "type": "string", "description": "ISO 3166-1 alpha-2 country code." },
+        "locationCountry": {
+          "type": "string",
+          "description": "Country name."
+        },
+        "locationRegion": {
+          "type": "string",
+          "description": "Region, state, or province."
+        },
+        "locationLocality": {
+          "type": "string",
+          "description": "City or locality."
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 alpha-2 country code."
+        },
         "location": {
           "type": "string",
           "description": "Assembled human-readable location string."
@@ -347,18 +452,25 @@
         "skillRkeys": {
           "type": "array",
           "description": "Record keys of skills linked to this position.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
-
     "educationView": {
       "type": "object",
       "description": "An education-history entry.",
       "required": ["rkey"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the education record." },
-        "institution": { "type": "string", "description": "Institution name." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the education record."
+        },
+        "institution": {
+          "type": "string",
+          "description": "Institution name."
+        },
         "institutionDid": {
           "type": "string",
           "format": "did",
@@ -369,22 +481,45 @@
           "format": "uri",
           "description": "Pointer URI to the resolved institution entity."
         },
-        "degree": { "type": "string", "description": "Degree earned." },
-        "fieldOfStudy": { "type": "string", "description": "Field of study." },
-        "activities": { "type": "string", "description": "Activities and societies." },
-        "description": { "type": "string", "description": "Additional description." },
-        "startedAt": { "type": "string", "description": "Start date. Partial date." },
-        "endedAt": { "type": "string", "description": "End date. Partial date." }
+        "degree": {
+          "type": "string",
+          "description": "Degree earned."
+        },
+        "fieldOfStudy": {
+          "type": "string",
+          "description": "Field of study."
+        },
+        "activities": {
+          "type": "string",
+          "description": "Activities and societies."
+        },
+        "description": {
+          "type": "string",
+          "description": "Additional description."
+        },
+        "startedAt": {
+          "type": "string",
+          "description": "Start date. Partial date."
+        },
+        "endedAt": {
+          "type": "string",
+          "description": "End date. Partial date."
+        }
       }
     },
-
     "skillView": {
       "type": "object",
       "description": "A skill entry.",
       "required": ["rkey", "name"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the skill record." },
-        "name": { "type": "string", "description": "Skill name." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the skill record."
+        },
+        "name": {
+          "type": "string",
+          "description": "Skill name."
+        },
         "category": {
           "type": "ref",
           "ref": "id.sifa.defs#skillCategory",
@@ -393,26 +528,42 @@
         "positionRkeys": {
           "type": "array",
           "description": "Record keys of positions this skill is linked to.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
-
     "certificationView": {
       "type": "object",
       "description": "A certification or license.",
       "required": ["rkey", "name"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the certification record." },
-        "name": { "type": "string", "description": "Certification name." },
-        "issuingOrg": { "type": "string", "description": "Issuing organization." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the certification record."
+        },
+        "name": {
+          "type": "string",
+          "description": "Certification name."
+        },
+        "issuingOrg": {
+          "type": "string",
+          "description": "Issuing organization."
+        },
         "entityRef": {
           "type": "string",
           "format": "uri",
           "description": "Pointer URI to the resolved issuer entity."
         },
-        "issueDate": { "type": "string", "description": "Issue date. Partial date." },
-        "expiryDate": { "type": "string", "description": "Expiry date. Partial date." },
+        "issueDate": {
+          "type": "string",
+          "description": "Issue date. Partial date."
+        },
+        "expiryDate": {
+          "type": "string",
+          "description": "Expiry date. Partial date."
+        },
         "credentialUrl": {
           "type": "string",
           "format": "uri",
@@ -420,41 +571,78 @@
         }
       }
     },
-
     "projectView": {
       "type": "object",
       "description": "A project entry.",
       "required": ["rkey", "name"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the project record." },
-        "name": { "type": "string", "description": "Project name." },
-        "description": { "type": "string", "description": "Project description." },
-        "url": { "type": "string", "format": "uri", "description": "Project URL." },
-        "startDate": { "type": "string", "description": "Start date. Partial date." },
-        "endDate": { "type": "string", "description": "End date. Partial date." }
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the project record."
+        },
+        "name": {
+          "type": "string",
+          "description": "Project name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Project description."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Project URL."
+        },
+        "startDate": {
+          "type": "string",
+          "description": "Start date. Partial date."
+        },
+        "endDate": {
+          "type": "string",
+          "description": "End date. Partial date."
+        }
       }
     },
-
     "volunteeringView": {
       "type": "object",
       "description": "A legacy volunteering entry.",
       "required": ["rkey", "organization"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the volunteering record." },
-        "organization": { "type": "string", "description": "Organization name." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the volunteering record."
+        },
+        "organization": {
+          "type": "string",
+          "description": "Organization name."
+        },
         "entityRef": {
           "type": "string",
           "format": "uri",
           "description": "Pointer URI to the resolved organization entity."
         },
-        "role": { "type": "string", "description": "Role held." },
-        "cause": { "type": "string", "description": "Cause supported." },
-        "description": { "type": "string", "description": "Description." },
-        "startDate": { "type": "string", "description": "Start date. Partial date." },
-        "endDate": { "type": "string", "description": "End date. Partial date." }
+        "role": {
+          "type": "string",
+          "description": "Role held."
+        },
+        "cause": {
+          "type": "string",
+          "description": "Cause supported."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description."
+        },
+        "startDate": {
+          "type": "string",
+          "description": "Start date. Partial date."
+        },
+        "endDate": {
+          "type": "string",
+          "description": "End date. Partial date."
+        }
       }
     },
-
     "involvementView": {
       "type": "object",
       "description": "A community, open-source, charity, or civic involvement.",
@@ -483,14 +671,29 @@
           "format": "uri",
           "description": "URL of the upstream, when provided."
         },
-        "role": { "type": "string", "description": "Role in the involvement." },
-        "description": { "type": "string", "description": "Description." },
-        "startedAt": { "type": "string", "description": "Start date. Partial date." },
-        "endedAt": { "type": "string", "description": "End date. Partial date." },
+        "role": {
+          "type": "string",
+          "description": "Role in the involvement."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description."
+        },
+        "startedAt": {
+          "type": "string",
+          "description": "Start date. Partial date."
+        },
+        "endedAt": {
+          "type": "string",
+          "description": "End date. Partial date."
+        },
         "links": {
           "type": "array",
           "description": "Public artifact links proving the work.",
-          "items": { "type": "ref", "ref": "#involvementLinkView" }
+          "items": {
+            "type": "ref",
+            "ref": "#involvementLinkView"
+          }
         },
         "legacy": {
           "type": "boolean",
@@ -498,18 +701,24 @@
         }
       }
     },
-
     "involvementLinkView": {
       "type": "object",
       "description": "A proof link on an involvement.",
       "required": ["url"],
       "properties": {
-        "url": { "type": "string", "format": "uri", "description": "Artifact URL." },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Artifact URL."
+        },
         "kind": {
           "type": "string",
           "description": "What the link points to (e.g. pull-request, talk, article)."
         },
-        "label": { "type": "string", "description": "Optional human-readable label." },
+        "label": {
+          "type": "string",
+          "description": "Optional human-readable label."
+        },
         "verified": {
           "type": "boolean",
           "description": "True if the link host matches a verified external account."
@@ -520,7 +729,6 @@
         }
       }
     },
-
     "publicationView": {
       "type": "object",
       "description": "A publication, merged from Sifa and linked ORCID works.",
@@ -530,25 +738,59 @@
           "type": "string",
           "description": "Record key, or a synthetic key for ORCID-only works."
         },
-        "title": { "type": "string", "description": "Publication title." },
-        "subtitle": { "type": "string", "description": "Subtitle." },
-        "publisher": { "type": "string", "description": "Publisher or journal." },
-        "date": { "type": "string", "description": "Publication date. Partial date." },
-        "url": { "type": "string", "format": "uri", "description": "Publication URL." },
-        "description": { "type": "string", "description": "Description or abstract." },
-        "doi": { "type": "string", "description": "Digital Object Identifier." },
-        "type": { "type": "string", "description": "Publication type token." },
-        "typeLabel": { "type": "string", "description": "Human-readable publication type." },
+        "title": {
+          "type": "string",
+          "description": "Publication title."
+        },
+        "subtitle": {
+          "type": "string",
+          "description": "Subtitle."
+        },
+        "publisher": {
+          "type": "string",
+          "description": "Publisher or journal."
+        },
+        "date": {
+          "type": "string",
+          "description": "Publication date. Partial date."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Publication URL."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description or abstract."
+        },
+        "doi": {
+          "type": "string",
+          "description": "Digital Object Identifier."
+        },
+        "type": {
+          "type": "string",
+          "description": "Publication type token."
+        },
+        "typeLabel": {
+          "type": "string",
+          "description": "Human-readable publication type."
+        },
         "contributors": {
           "type": "array",
           "description": "Linked contributors (co-authors).",
-          "items": { "type": "ref", "ref": "#contributorView" }
+          "items": {
+            "type": "ref",
+            "ref": "#contributorView"
+          }
         },
         "verified": {
           "type": "boolean",
           "description": "Whether the publication is verified (e.g. via ORCID)."
         },
-        "verifiedVia": { "type": "string", "description": "Verification source, when verified." },
+        "verifiedVia": {
+          "type": "string",
+          "description": "Verification source, when verified."
+        },
         "orcidCorroborated": {
           "type": "boolean",
           "description": "Whether an ORCID work corroborates a Sifa record."
@@ -567,35 +809,59 @@
           "type": "string",
           "description": "Name of the source publication venue, when present."
         },
-        "image": { "type": "string", "format": "uri", "description": "Cover or preview image URL." }
+        "image": {
+          "type": "string",
+          "format": "uri",
+          "description": "Cover or preview image URL."
+        }
       }
     },
-
     "contributorView": {
       "type": "object",
       "description": "A linked publication contributor.",
       "required": ["name"],
       "properties": {
-        "name": { "type": "string", "description": "Contributor name." },
-        "orcidId": { "type": "string", "description": "ORCID identifier." },
+        "name": {
+          "type": "string",
+          "description": "Contributor name."
+        },
+        "orcidId": {
+          "type": "string",
+          "description": "ORCID identifier."
+        },
         "did": {
           "type": "string",
           "format": "did",
           "description": "Sifa/AT Protocol DID, when linked."
         },
-        "handle": { "type": "string", "format": "handle", "description": "Handle, when linked." }
+        "handle": {
+          "type": "string",
+          "format": "handle",
+          "description": "Handle, when linked."
+        }
       }
     },
-
     "courseView": {
       "type": "object",
       "description": "A course entry.",
       "required": ["rkey", "name"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the course record." },
-        "name": { "type": "string", "description": "Course name." },
-        "number": { "type": "string", "description": "Course number or code." },
-        "institution": { "type": "string", "description": "Institution name." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the course record."
+        },
+        "name": {
+          "type": "string",
+          "description": "Course name."
+        },
+        "number": {
+          "type": "string",
+          "description": "Course number or code."
+        },
+        "institution": {
+          "type": "string",
+          "description": "Institution name."
+        },
         "entityRef": {
           "type": "string",
           "format": "uri",
@@ -607,15 +873,23 @@
         }
       }
     },
-
     "presentationView": {
       "type": "object",
       "description": "A talk or session (content), with its deliveries grouped underneath.",
       "required": ["rkey", "title", "deliveries"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the presentation record." },
-        "title": { "type": "string", "description": "Presentation title." },
-        "description": { "type": "string", "description": "Presentation description." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the presentation record."
+        },
+        "title": {
+          "type": "string",
+          "description": "Presentation title."
+        },
+        "description": {
+          "type": "string",
+          "description": "Presentation description."
+        },
         "duration": {
           "type": "ref",
           "ref": "#durationView",
@@ -624,12 +898,17 @@
         "intendedAudiences": {
           "type": "array",
           "description": "Intended audiences.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "links": {
           "type": "array",
           "description": "Related links (slides, recording, etc.).",
-          "items": { "type": "ref", "ref": "id.sifa.defs#presentationLink" }
+          "items": {
+            "type": "ref",
+            "ref": "id.sifa.defs#presentationLink"
+          }
         },
         "writeupUri": {
           "type": "string",
@@ -639,27 +918,37 @@
         "deliveries": {
           "type": "array",
           "description": "Deliveries of this presentation.",
-          "items": { "type": "ref", "ref": "#presentationDeliveryView" }
+          "items": {
+            "type": "ref",
+            "ref": "#presentationDeliveryView"
+          }
         }
       }
     },
-
     "durationView": {
       "type": "object",
       "description": "A duration range in minutes.",
       "required": ["minMinutes"],
       "properties": {
-        "minMinutes": { "type": "integer", "description": "Minimum duration in minutes." },
-        "maxMinutes": { "type": "integer", "description": "Maximum duration in minutes." }
+        "minMinutes": {
+          "type": "integer",
+          "description": "Minimum duration in minutes."
+        },
+        "maxMinutes": {
+          "type": "integer",
+          "description": "Maximum duration in minutes."
+        }
       }
     },
-
     "presentationDeliveryView": {
       "type": "object",
       "description": "A single delivery of a presentation at an occasion.",
       "required": ["rkey"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the delivery record." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the delivery record."
+        },
         "presentationRkey": {
           "type": "string",
           "description": "Record key of the parent presentation, when grouped."
@@ -673,18 +962,33 @@
           "ref": "id.sifa.defs#presentationRole",
           "description": "The user's role in the delivery."
         },
-        "eventName": { "type": "string", "description": "Name of the event or occasion." },
-        "date": { "type": "string", "description": "Delivery date. Partial date." },
-        "location": { "type": "string", "description": "Event location." },
+        "eventName": {
+          "type": "string",
+          "description": "Name of the event or occasion."
+        },
+        "date": {
+          "type": "string",
+          "description": "Delivery date. Partial date."
+        },
+        "location": {
+          "type": "string",
+          "description": "Event location."
+        },
         "mode": {
           "type": "string",
           "description": "Delivery mode (e.g. in-person, remote, hybrid)."
         },
-        "status": { "type": "string", "description": "Delivery status." },
+        "status": {
+          "type": "string",
+          "description": "Delivery status."
+        },
         "links": {
           "type": "array",
           "description": "Related links for this delivery.",
-          "items": { "type": "ref", "ref": "id.sifa.defs#presentationLink" }
+          "items": {
+            "type": "ref",
+            "ref": "id.sifa.defs#presentationLink"
+          }
         },
         "eventUri": {
           "type": "string",
@@ -694,11 +998,13 @@
         "coSpeakers": {
           "type": "array",
           "description": "Co-speakers on this delivery.",
-          "items": { "type": "ref", "ref": "#coSpeakerView" }
+          "items": {
+            "type": "ref",
+            "ref": "#coSpeakerView"
+          }
         }
       }
     },
-
     "coSpeakerView": {
       "type": "object",
       "description": "A co-speaker on a presentation delivery.",
@@ -708,38 +1014,71 @@
           "format": "did",
           "description": "DID of the co-speaker, when linked to a Sifa profile."
         },
-        "handle": { "type": "string", "format": "handle", "description": "Handle, when linked." },
-        "displayName": { "type": "string", "description": "Display name, when linked." },
-        "avatar": { "type": "string", "format": "uri", "description": "Avatar URL, when linked." },
-        "name": { "type": "string", "description": "Free-text co-speaker name, when not linked." }
+        "handle": {
+          "type": "string",
+          "format": "handle",
+          "description": "Handle, when linked."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name, when linked."
+        },
+        "avatar": {
+          "type": "string",
+          "format": "uri",
+          "description": "Avatar URL, when linked."
+        },
+        "name": {
+          "type": "string",
+          "description": "Free-text co-speaker name, when not linked."
+        }
       }
     },
-
     "honorView": {
       "type": "object",
       "description": "An honor or award.",
       "required": ["rkey", "title"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the honor record." },
-        "title": { "type": "string", "description": "Honor or award title." },
-        "issuer": { "type": "string", "description": "Issuing organization." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the honor record."
+        },
+        "title": {
+          "type": "string",
+          "description": "Honor or award title."
+        },
+        "issuer": {
+          "type": "string",
+          "description": "Issuing organization."
+        },
         "entityRef": {
           "type": "string",
           "format": "uri",
           "description": "Pointer URI to the resolved issuer entity."
         },
-        "description": { "type": "string", "description": "Description." },
-        "date": { "type": "string", "description": "Date received. Partial date." }
+        "description": {
+          "type": "string",
+          "description": "Description."
+        },
+        "date": {
+          "type": "string",
+          "description": "Date received. Partial date."
+        }
       }
     },
-
     "languageView": {
       "type": "object",
       "description": "A language with proficiency.",
       "required": ["rkey", "language"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the language record." },
-        "language": { "type": "string", "description": "Language name or BCP-47 tag." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the language record."
+        },
+        "language": {
+          "type": "string",
+          "description": "Language name or BCP-47 tag."
+        },
         "proficiency": {
           "type": "ref",
           "ref": "id.sifa.defs#proficiency",
@@ -747,44 +1086,73 @@
         }
       }
     },
-
     "externalAccountView": {
       "type": "object",
       "description": "A linked external account with verification state.",
       "required": ["rkey", "url"],
       "properties": {
-        "rkey": { "type": "string", "description": "Record key of the external account record." },
+        "rkey": {
+          "type": "string",
+          "description": "Record key of the external account record."
+        },
         "platform": {
           "type": "ref",
           "ref": "id.sifa.defs#externalPlatform",
           "description": "Platform type."
         },
-        "url": { "type": "string", "format": "uri", "description": "Account URL." },
-        "label": { "type": "string", "description": "Optional custom label." },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Account URL."
+        },
+        "label": {
+          "type": "string",
+          "description": "Optional custom label."
+        },
         "feedUrl": {
           "type": "string",
           "format": "uri",
           "description": "Feed URL (RSS/Atom), when applicable."
         },
-        "verifiable": { "type": "boolean", "description": "Whether the account can be verified." },
-        "verified": { "type": "boolean", "description": "Whether the account is verified." },
-        "verifiedVia": { "type": "string", "description": "Verification method, when verified." },
+        "verifiable": {
+          "type": "boolean",
+          "description": "Whether the account can be verified."
+        },
+        "verified": {
+          "type": "boolean",
+          "description": "Whether the account is verified."
+        },
+        "verifiedVia": {
+          "type": "string",
+          "description": "Verification method, when verified."
+        },
         "primary": {
           "type": "boolean",
           "description": "Whether this is the primary external account."
         }
       }
     },
-
     "activeAppView": {
       "type": "object",
       "description": "An AT Protocol app the account has recently created records in.",
       "required": ["id", "name"],
       "properties": {
-        "id": { "type": "string", "description": "App identifier." },
-        "name": { "type": "string", "description": "App display name." },
-        "category": { "type": "string", "description": "App category." },
-        "recentCount": { "type": "integer", "description": "Recent record count." },
+        "id": {
+          "type": "string",
+          "description": "App identifier."
+        },
+        "name": {
+          "type": "string",
+          "description": "App display name."
+        },
+        "category": {
+          "type": "string",
+          "description": "App category."
+        },
+        "recentCount": {
+          "type": "integer",
+          "description": "Recent record count."
+        },
         "latestRecordAt": {
           "type": "string",
           "format": "datetime",
@@ -792,14 +1160,20 @@
         }
       }
     },
-
     "atfundLink": {
       "type": "object",
       "description": "A contribution or funding link.",
       "required": ["url"],
       "properties": {
-        "url": { "type": "string", "format": "uri", "description": "Contribution URL." },
-        "label": { "type": "string", "description": "Optional display label." }
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Contribution URL."
+        },
+        "label": {
+          "type": "string",
+          "description": "Optional display label."
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -695,6 +695,93 @@ describe('id.sifa.defs involvement additions', () => {
   });
 });
 
+describe('id.sifa.getProfileView query lexicon', () => {
+  interface XrpcDoc {
+    defs: {
+      main: {
+        type: string;
+        parameters?: { required?: string[]; properties?: Record<string, LexiconProperty> };
+        output?: { encoding?: string; schema?: LexiconProperty };
+        errors?: { name: string; description?: string }[];
+      };
+      profileView?: {
+        type: string;
+        required?: string[];
+        properties?: Record<string, LexiconProperty>;
+      };
+    } & Record<string, { type: string }>;
+  }
+  const doc = JSON.parse(
+    readFileSync(join(LEXICONS_DIR, 'getProfileView.json'), 'utf-8'),
+  ) as XrpcDoc;
+
+  it('main is a query with a required at-identifier actor param', () => {
+    expect(doc.defs.main.type).toBe('query');
+    expect(doc.defs.main.parameters?.required).toContain('actor');
+    expect(doc.defs.main.parameters?.properties?.actor?.type).toBe('string');
+    expect(doc.defs.main.parameters?.properties?.actor?.format).toBe('at-identifier');
+  });
+
+  it('outputs application/json referencing #profileView', () => {
+    expect(doc.defs.main.output?.encoding).toBe('application/json');
+    expect(doc.defs.main.output?.schema?.type).toBe('ref');
+    expect(doc.defs.main.output?.schema?.ref).toBe('#profileView');
+  });
+
+  it('declares a ProfileNotFound error', () => {
+    expect(doc.defs.main.errors?.map((e) => e.name)).toContain('ProfileNotFound');
+  });
+
+  it('profileView requires did and handle', () => {
+    expect(doc.defs.profileView?.type).toBe('object');
+    expect(doc.defs.profileView?.required).toEqual(expect.arrayContaining(['did', 'handle']));
+    expect(doc.defs.profileView?.properties?.did?.format).toBe('did');
+    expect(doc.defs.profileView?.properties?.handle?.format).toBe('handle');
+  });
+
+  it.each([
+    ['positions', '#positionView'],
+    ['education', '#educationView'],
+    ['skills', '#skillView'],
+    ['certifications', '#certificationView'],
+    ['projects', '#projectView'],
+    ['volunteering', '#volunteeringView'],
+    ['involvement', '#involvementView'],
+    ['publications', '#publicationView'],
+    ['courses', '#courseView'],
+    ['presentations', '#presentationView'],
+    ['presentationDeliveries', '#presentationDeliveryView'],
+    ['honors', '#honorView'],
+    ['languages', '#languageView'],
+    ['externalAccounts', '#externalAccountView'],
+    ['locations', '#locationView'],
+    ['activeApps', '#activeAppView'],
+  ] as const)('profileView.%s is an array of %s', (field, ref) => {
+    const prop = doc.defs.profileView?.properties?.[field];
+    expect(prop?.type).toBe('array');
+    expect(prop?.items?.type).toBe('ref');
+    expect(prop?.items?.ref).toBe(ref);
+  });
+
+  it('every local def referenced by the view is defined in the document', () => {
+    const defNames = new Set(Object.keys(doc.defs));
+    const localRefs = new Set<string>();
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== 'object') return;
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        if (key === 'ref' && typeof value === 'string' && value.startsWith('#')) {
+          localRefs.add(value.slice(1));
+        }
+        walk(value);
+      }
+    };
+    walk(doc.defs);
+    for (const ref of localRefs) {
+      expect(defNames, `local ref #${ref} must resolve to a def`).toContain(ref);
+    }
+  });
+});
+
 describe('openToWorkStatus commissions token', () => {
   interface DefsDoc {
     defs: {


### PR DESCRIPTION
## What

Adds `id.sifa.getProfileView`, the first XRPC `query` lexicon in the repo. It defines the aggregated public professional profile view: a user's `id.sifa.*` records joined across all sections (positions, education, skills, certifications, projects, involvement, publications, courses, presentations, honors, languages, external accounts, locations) plus AppView-computed aggregates (follower/connection/meeting counts, active apps, Bluesky verification).

## Why

Raw `id.sifa.*` records are already portable and readable straight from a user's PDS. The joined, enriched view is not: it only exists in an AppView. Publishing a `query` lexicon gives third parties a standard, typed contract to read that view via service proxying, instead of calling a bespoke REST endpoint.

The response is a curated public projection. Viewer-specific and internal fields (ownership flags, presentation/override internals, unverified-publication plumbing) are intentionally excluded so the published contract stays clean.

## Scope

This PR is the contract only. Serving it in sifa-api and adding a typed fetcher in sifa-sdk are follow-up PRs.

## Testing

- `npm run generate` validates the lexicon and generates a typed query client (all refs resolve, `tsc --noEmit` clean).
- New `tests/lexicons.test.ts` block asserts the query shape: `actor` param, `#profileView` output, `ProfileNotFound` error, section array refs, and that every local `#ref` resolves. Full suite: 327 passing.

Minor bump 0.9.3 to 0.10.0 (new lexicon file).

Refs #264
