### PR TITLE
feat(profile): coverImage blob + structured delivery address

### DIFF
--- a/lexicons/id/sifa/profile/presentation.json
+++ b/lexicons/id/sifa/profile/presentation.json
@@ -53,6 +53,12 @@
             "ref": "id.sifa.defs#externalRecordRef",
             "description": "Optional reference to a long-form write-up of this presentation (a pub.leaflet.document or site.standard.document holding video, transcript, or article)."
           },
+          "coverImage": {
+            "type": "blob",
+            "accept": ["image/png", "image/jpeg", "image/webp"],
+            "maxSize": 2000000,
+            "description": "Optional cover image for the presentation. Rendered as the talk-page hero and OpenGraph image. Max 2 MB, PNG, JPEG, or WebP."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/lexicons/id/sifa/profile/presentationDelivery.json
+++ b/lexicons/id/sifa/profile/presentationDelivery.json
@@ -50,7 +50,12 @@
             "type": "string",
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Display location (city, country, or venue). On the linked branch, composed from the calendar event's structured locations."
+            "description": "Legacy free-text display location (city, country, or venue), retained for dual-read. Prefer the structured address field. On the linked branch, composed from the calendar event's structured locations."
+          },
+          "address": {
+            "type": "ref",
+            "ref": "community.lexicon.location.address",
+            "description": "Structured delivery location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer and surfaces country (for a flag) and locality (city); region, postalCode, and street are unused for deliveries. Takes precedence over the legacy location string when present."
           },
           "mode": {
             "type": "string",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -558,6 +558,60 @@ describe('community location adoption', () => {
   }
 });
 
+describe('id.sifa.profile.presentation coverImage field', () => {
+  const lexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.presentation');
+  const properties = lexicon?.doc.defs.main.record?.properties;
+  const required = lexicon?.doc.defs.main.record?.required ?? [];
+
+  it('lexicon exists', () => {
+    expect(lexicon).toBeDefined();
+  });
+
+  it('coverImage exists as an optional blob field', () => {
+    expect(properties?.coverImage).toBeDefined();
+    expect(properties?.coverImage?.type).toBe('blob');
+    expect(required).not.toContain('coverImage');
+  });
+
+  it('coverImage accepts png, jpeg, and webp', () => {
+    expect(properties?.coverImage?.accept).toEqual(['image/png', 'image/jpeg', 'image/webp']);
+  });
+
+  it('coverImage caps at 2MB', () => {
+    expect(properties?.coverImage?.maxSize).toBe(2000000);
+  });
+
+  it('coverImage has a description', () => {
+    expect(properties?.coverImage?.description).toBeDefined();
+    expect(properties?.coverImage?.description!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('id.sifa.profile.presentationDelivery address field', () => {
+  const lexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.presentationDelivery');
+  const properties = lexicon?.doc.defs.main.record?.properties;
+  const required = lexicon?.doc.defs.main.record?.required ?? [];
+
+  it('lexicon exists', () => {
+    expect(lexicon).toBeDefined();
+  });
+
+  it('address is an optional community.lexicon.location.address ref', () => {
+    expect(properties?.address?.type).toBe('ref');
+    expect(properties?.address?.ref).toBe('community.lexicon.location.address');
+    expect(required).not.toContain('address');
+  });
+
+  it('retains the legacy free-text location string for dual-read', () => {
+    expect(properties?.location?.type).toBe('string');
+  });
+
+  it('address has a description', () => {
+    expect(properties?.address?.description).toBeDefined();
+    expect(properties?.address?.description!.length).toBeGreaterThan(0);
+  });
+});
+
 describe('id.sifa.profile.involvement lexicon', () => {
   const involvement = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.involvement');
   const properties = involvement?.doc.defs.main.record?.properties;


### PR DESCRIPTION
Adds two additive, dual-read fields to the speaking-engagement lexicons.

- `id.sifa.profile.presentation` gains an optional `coverImage` blob (PNG, JPEG, or WebP; max 2 MB), for a talk-page hero and OpenGraph image. Mirrors the existing `profile.self.avatar` blob pattern.
- `id.sifa.profile.presentationDelivery` gains an optional `address` ref to `community.lexicon.location.address` (ISO 3166-1 alpha-2 country + city), reusing the same structured-location pattern as the profile about section. This gives deliveries a country flag and a clean "City, Country". The legacy free-text `location` string is retained and its description now notes the structured field takes precedence, so existing records keep rendering via fallback.

Both changes are additive: existing records validate unchanged, and no new write scope is needed (both collections are already writable).

Tests cover the new field shapes (blob accept list and size, address ref target, dual-read string retained). Downstream sifa-api, sifa-sdk, and sifa-web changes follow in separate PRs.

Part of singi-labs/sifa-workspace#269
