### PR TITLE
feat(org): add addresses, companySize, links to id.sifa.org.profile

### DIFF
--- a/lexicons/id/sifa/org/profile.json
+++ b/lexicons/id/sifa/org/profile.json
@@ -48,6 +48,52 @@
             "type": "string",
             "description": "Contact email address for the organization. NOT rendered publicly; used for notifications only. Validated as an email address at the app layer."
           },
+          "addresses": {
+            "type": "array",
+            "maxLength": 10,
+            "items": {
+              "type": "ref",
+              "ref": "community.lexicon.location.address"
+            },
+            "description": "Physical addresses for the organization (headquarters, offices). Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
+          },
+          "companySize": {
+            "type": "string",
+            "knownValues": [
+              "1-10",
+              "11-50",
+              "51-200",
+              "201-500",
+              "501-1000",
+              "1001-5000",
+              "5001-10000",
+              "10001+"
+            ],
+            "description": "Self-selected headcount range for the organization. A declared bucket, never a calculated count. Open knownValues so future ranges do not break older records."
+          },
+          "links": {
+            "type": "array",
+            "maxLength": 10,
+            "items": {
+              "type": "object",
+              "required": ["name", "url"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "maxGraphemes": 60,
+                  "maxLength": 600,
+                  "description": "Display label for the link."
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "maxLength": 2048,
+                  "description": "Destination URL."
+                }
+              }
+            },
+            "description": "Featured links or content surfaced on the organization profile."
+          },
           "labels": {
             "type": "union",
             "description": "Self-label values for this organization profile.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -836,6 +836,83 @@ describe('id.sifa.getProfileView query lexicon', () => {
   });
 });
 
+describe('id.sifa.org.profile addresses, companySize, links fields', () => {
+  const orgProfile = recordLexicons.find((l) => l.doc.id === 'id.sifa.org.profile');
+  const properties = orgProfile?.doc.defs.main.record?.properties;
+  const required = orgProfile?.doc.defs.main.record?.required ?? [];
+
+  it('lexicon exists', () => {
+    expect(orgProfile).toBeDefined();
+  });
+
+  it('none of the three new fields are required (all additive/optional)', () => {
+    expect(required).not.toContain('addresses');
+    expect(required).not.toContain('companySize');
+    expect(required).not.toContain('links');
+  });
+
+  describe('addresses', () => {
+    it('is an array of community.lexicon.location.address refs with maxLength 10', () => {
+      expect(properties?.addresses?.type).toBe('array');
+      expect(properties?.addresses?.maxLength).toBe(10);
+      expect(properties?.addresses?.items?.type).toBe('ref');
+      expect(properties?.addresses?.items?.ref).toBe('community.lexicon.location.address');
+    });
+
+    it('has a description', () => {
+      expect(properties?.addresses?.description).toBeDefined();
+      expect(properties?.addresses?.description!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('companySize', () => {
+    it('is a string with open knownValues (not a hard enum)', () => {
+      expect(properties?.companySize?.type).toBe('string');
+      expect((properties?.companySize as { knownValues?: string[] })?.knownValues).toEqual([
+        '1-10',
+        '11-50',
+        '51-200',
+        '201-500',
+        '501-1000',
+        '1001-5000',
+        '5001-10000',
+        '10001+',
+      ]);
+      expect((properties?.companySize as { enum?: string[] })?.enum).toBeUndefined();
+    });
+
+    it('has a description', () => {
+      expect(properties?.companySize?.description).toBeDefined();
+      expect(properties?.companySize?.description!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('links', () => {
+    it('is an array of inline objects with maxLength 10', () => {
+      expect(properties?.links?.type).toBe('array');
+      expect(properties?.links?.maxLength).toBe(10);
+      expect(properties?.links?.items?.type).toBe('object');
+    });
+
+    it('each link requires name and url', () => {
+      expect(properties?.links?.items?.required).toEqual(['name', 'url']);
+    });
+
+    it('name is a capped string (60 graphemes)', () => {
+      const name = properties?.links?.items?.properties?.name;
+      expect(name?.type).toBe('string');
+      expect(name?.maxGraphemes).toBe(60);
+    });
+
+    it('url is a uri-format string capped at 2048', () => {
+      const url = properties?.links?.items?.properties?.url;
+      expect(url?.type).toBe('string');
+      expect(url?.format).toBe('uri');
+      expect(url?.maxLength).toBe(2048);
+    });
+  });
+});
+
 describe('openToWorkStatus commissions token', () => {
   interface DefsDoc {
     defs: {


### PR DESCRIPTION
## What

Adds three optional, additive fields to `id.sifa.org.profile` for the org page data model (first-class organizations, Phase 1):

- `addresses`: array (max 10) of `community.lexicon.location.address` refs. Reuses the existing external location lexicon already referenced by `position`, `education`, `self`, `location`, and `presentationDelivery`, rather than defining a new inline address shape.
- `companySize`: string with open `knownValues` (`1-10`, `11-50`, `51-200`, `201-500`, `501-1000`, `1001-5000`, `5001-10000`, `10001+`). A selected range, never a calculated count. Open knownValues (not a hard enum) so future ranges do not break older records.
- `links`: array (max 10) of an inline object with a required `name` (60 graphemes) and required `url` (uri, 2048 chars). Featured links surfaced on the org profile.

All three are optional, so existing records stay valid.

## Versioning

Additive change, so this is a patch bump of the package version, from 0.10.0 to 0.10.1, matching the repo convention for adding optional fields.

## Hold the publish before merging

The `Publish lexicons` workflow triggers on push to `main` for any change under `lexicons/**/*.json`, so merging this PR would auto-republish every schema to the authority DID. The authority-DID publish is on hold for Guido. Keep this PR unmerged until the hold is lifted, or gate the workflow for this merge.

## Tests

New test cases assert the shape, ref target, open knownValues behavior, required link fields, and the max array lengths. Full suite of 350 tests passes, plus lint and format checks.
