### PR TITLE
feat(profile): add optional subCategory to id.sifa.profile.skill

### DIFF
--- a/lexicons/id/sifa/profile/skill.json
+++ b/lexicons/id/sifa/profile/skill.json
@@ -30,6 +30,12 @@
               "id.sifa.defs#industry"
             ]
           },
+          "subCategory": {
+            "type": "string",
+            "maxGraphemes": 64,
+            "maxLength": 640,
+            "description": "Optional user-defined grouping label nested under category (e.g., 'Frontend', 'Backend', 'Databases'). Freeform: unlike category there are no known values, so renderers can present skills in the user's own groups. Renderers decide the display label."
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -105,6 +105,7 @@ const USER_TEXT_FIELDS = new Set([
   'companyName',
   'title',
   'subtitle',
+  'subCategory',
   'institution',
   'name',
   'comment',
@@ -412,6 +413,35 @@ describe('Publication subtitle field', () => {
   it('subtitle has a description', () => {
     expect(properties?.subtitle?.description).toBeDefined();
     expect(properties?.subtitle?.description!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Skill subCategory field', () => {
+  const skillLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.skill');
+  const properties = skillLexicon?.doc.defs.main.record?.properties;
+  const required = skillLexicon?.doc.defs.main.record?.required ?? [];
+
+  it('subCategory exists as an optional string', () => {
+    expect(properties?.subCategory).toBeDefined();
+    expect(properties?.subCategory?.type).toBe('string');
+  });
+
+  it('subCategory is freeform (no knownValues, unlike category)', () => {
+    expect((properties?.subCategory as { knownValues?: string[] })?.knownValues).toBeUndefined();
+  });
+
+  it('subCategory matches the name field length constraints (64/640)', () => {
+    expect(properties?.subCategory?.maxGraphemes).toBe(64);
+    expect(properties?.subCategory?.maxLength).toBe(640);
+  });
+
+  it('subCategory is not required (skills need no grouping)', () => {
+    expect(required).not.toContain('subCategory');
+  });
+
+  it('subCategory description mentions the user-defined grouping under category', () => {
+    expect(properties?.subCategory?.description).toBeDefined();
+    expect(properties?.subCategory?.description).toMatch(/category/i);
   });
 });
 


### PR DESCRIPTION
## What

Adds an optional freeform `subCategory` string to `id.sifa.profile.skill`.

## Why

The existing `category` field sorts skills into six broad buckets. People arranging a profile or a rendered site often want finer groups like Frontend, Backend, or Databases. `subCategory` gives them a grouping label nested under `category`, without locking everyone into a single fixed taxonomy.

## Details

- Optional freeform string, no known values, maxGraphemes 64 and maxLength 640 to match the `name` field.
- Additive, so existing skill records validate unchanged. Patch bump to 0.10.1.
- Renderers decide the display label. The lexicon stores the grouping key only.

Part of the skill grouping work in singi-labs/sifa-workspace#305 (SDK and web changes follow).
