### PR TITLE
feat(org): add optional personalProfileVisible to org profile

### DIFF
--- a/lexicons/id/sifa/org/profile.json
+++ b/lexicons/id/sifa/org/profile.json
@@ -48,6 +48,11 @@
             "type": "string",
             "description": "Contact email address for the organization. NOT rendered publicly; used for notifications only. Validated as an email address at the app layer."
           },
+          "personalProfileVisible": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the account holder's personal profile stays publicly visible alongside this organization profile. For sole traders and one-person businesses whose personal domain is also their trade name: the person and the organization are the same account, and both pages render. When false or absent, the account presents solely as an organization and the personal profile is not rendered."
+          },
           "labels": {
             "type": "union",
             "description": "Self-label values for this organization profile.",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -19,6 +19,7 @@ interface LexiconProperty {
   items?: LexiconProperty;
   properties?: Record<string, LexiconProperty>;
   required?: string[];
+  default?: boolean;
 }
 
 interface LexiconDef {
@@ -639,6 +640,24 @@ describe('id.sifa.profile.presentationDelivery address field', () => {
   it('address has a description', () => {
     expect(properties?.address?.description).toBeDefined();
     expect(properties?.address?.description!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('id.sifa.org.profile lexicon', () => {
+  const orgProfile = recordLexicons.find((l) => l.doc.id === 'id.sifa.org.profile');
+  const properties = orgProfile?.doc.defs.main.record?.properties;
+  const required = orgProfile?.doc.defs.main.record?.required ?? [];
+
+  it('personalProfileVisible is an optional boolean defaulting to false', () => {
+    expect(properties?.personalProfileVisible?.type).toBe('boolean');
+    expect(properties?.personalProfileVisible?.default).toBe(false);
+    expect(required).not.toContain('personalProfileVisible');
+  });
+
+  it('personalProfileVisible describes the sole-trader case it exists for', () => {
+    const description = properties?.personalProfileVisible?.description ?? '';
+    expect(description).toMatch(/sole trader/i);
+    expect(description).toMatch(/personal profile/i);
   });
 });
 


### PR DESCRIPTION
Step 1 of 4 for singi-labs/sifa-workspace#327 (freelancer dual identity).

A sole trader's personal domain is both their name and their trade name. Today, claiming that domain as an organization hides their personal profile: a DID presents as a person or an organization, never both. @vsantele.dev hit exactly this asking to register `vsantele.dev` as a company, which would take down his CV at https://sifa.id/p/vsantele.dev.

This adds one optional boolean to `id.sifa.org.profile`:

```json
"personalProfileVisible": {
  "type": "boolean",
  "default": false
}
```

Optional and defaulting to `false`, so every existing record keeps today's exclusive behaviour. Set to `true`, the account renders at both `/p/` and `/c/`.

Named presentationally rather than legally. `soleTrader` was rejected: a two-person agency on a personal domain has the same need, and the field should not assert a legal form Sifa cannot verify.

Design doc: `decisions/2026-07-26-freelancer-dual-identity.md` in the Sifa workspace.

## Tests

Two new cases in `tests/lexicons.test.ts` pinning the field as an optional boolean defaulting to false, and pinning the description to the case it exists for. 348 pass; validate, typecheck, lint, and format:check clean.

## Next in the chain

sifa-api (column + verdict + `hasPersonalContent`), then sifa-sdk (types), then sifa-web (routing, cross-links, claim wizard).