### PR TITLE
feat(endorsement): allow endorsing a skill the subject has not listed

### DIFF
--- a/lexicons/id/sifa/endorsement.json
+++ b/lexicons/id/sifa/endorsement.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.endorsement",
-  "description": "An endorsement of another user's skill. Lives in the endorser's PDS; the endorser is implicit (whoever owns the repository).",
+  "description": "An endorsement of another user's skill. Lives in the endorser's PDS; the endorser is implicit (whoever owns the repository). May endorse a skill the subject already lists, or propose one they do not.",
   "defs": {
     "main": {
       "type": "record",
@@ -9,7 +9,7 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subject", "skill", "skillName", "createdAt"],
+        "required": ["subject", "skillName", "createdAt"],
         "properties": {
           "subject": {
             "type": "string",
@@ -19,14 +19,14 @@
           "skill": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "StrongRef to the id.sifa.profile.skill record being endorsed. The AT-URI identifies the skill, and the CID pins the version."
+            "description": "StrongRef to the id.sifa.profile.skill record being endorsed. The AT-URI identifies the skill, and the CID pins the version. Optional: when absent, the endorser is proposing a skill the subject has not listed, named by skillName. The subject materialises the skill record on acceptance and links it from their id.sifa.endorsement.confirmation, since only they can write to their own repository."
           },
           "skillName": {
             "type": "string",
             "minLength": 1,
             "maxGraphemes": 64,
             "maxLength": 640,
-            "description": "Skill name at endorsement time, captured from the endorsed record. This is the anchor field: if the skill is later renamed, this value lets the AppView detect that the endorsed claim may no longer match the current record. Stored in the endorser's PDS, so the endorsee cannot modify it."
+            "description": "Skill name at endorsement time. When skill is present this is captured from the endorsed record and acts as the anchor: if the skill is later renamed, this value lets the AppView detect that the endorsed claim may no longer match the current record. When skill is absent this is the proposed name for a skill the subject does not yet have. Stored in the endorser's PDS, so the endorsee cannot modify it."
           },
           "comment": {
             "type": "string",

--- a/lexicons/id/sifa/endorsement/confirmation.json
+++ b/lexicons/id/sifa/endorsement/confirmation.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.endorsement.confirmation",
-  "description": "Confirmation that a skill endorsement should be displayed on the subject's profile. Lives in the subject's PDS. Without this record, the endorsement exists but is not shown on the profile.",
+  "description": "Confirmation that a skill endorsement should be displayed on the subject's profile. Lives in the subject's PDS. Without this record, the endorsement exists but is not shown on the profile. When the endorsement proposed a new skill, this record also links the skill it materialised into.",
   "defs": {
     "main": {
       "type": "record",
@@ -15,6 +15,11 @@
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
             "description": "StrongRef to the id.sifa.endorsement record being confirmed. The AT-URI identifies the endorsement, and the CID pins the version at confirmation time."
+          },
+          "skill": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the id.sifa.profile.skill record this endorsement applies to. Set when confirming an endorsement that proposed a skill: the subject creates the skill record and links it here. The endorser cannot record this themselves, because the skill lives in the subject's repository and did not exist when they endorsed. May point at a skill the subject already had, when the proposed name matched one."
           },
           "createdAt": {
             "type": "string",


### PR DESCRIPTION
Lexicon half of endorsement skill suggestions. Decision doc: `Workspaces/Sifa/decisions/2026-07-30-endorsement-skill-suggestions.md`. Refs singi-labs/sifa-workspace#3.

## The gap

`skill` was required, so an endorsement could only point at a skill record that already existed on the subject's PDS. You could only endorse someone for something they had already written down.

Concretely: someone asked to endorse a connection as a "world class excellent food captain". She has 13 skill records and no "Food Captain", so the closest possible action was endorsing an unrelated skill with a comment.

## Changes

**`id.sifa.endorsement`** — `skill` moves out of `required`. Absent means the endorser is proposing a skill the subject does not have, named by `skillName`.

**`id.sifa.endorsement.confirmation`** — gains an optional `skill` strongRef: the record the endorsement materialised into.

## Why the link lives on the confirmation

This is the part worth reviewing. The obvious design is for the endorsement to carry the skill ref, and it cannot:

- The skill record lives in the **subject's** repository and does not exist when the endorsement is written.
- The endorser cannot add it afterwards. An AppView holds the subject's session at confirm time, not the endorser's, so there is no way to amend their record on their behalf — and doing so would mean holding the pending endorsement in a server-side table, making Sifa the source of truth for a record that does not yet exist in ATproto.

Putting it on the confirmation puts the write in the hands of the only party who can make it, and keeps the whole chain — proposed, accepted, resulting record — readable from the two PDSes alone.

It is also set when the proposed name matched a skill the subject already had, so a confirmation always says which record the endorsement applies to.

## Safety

`skillName` was already free text with the same validation, so a proposed name is no less constrained than one the subject typed. The difference is only who typed it first, and acceptance settles that. Nothing displays until the subject confirms, so an unwanted proposal reaches the inbox and stops there.

## Testing

348 pass. `npm run validate` regenerates cleanly.

Consumers follow: sifa-api (nullable columns, two-record accept, count resolution), sifa-sdk (schemas and types), sifa-web (inbox copy — accepting does two things and must say so).