### PR TITLE
feat(lexicons): add generic id.sifa.confirmation and project members

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,23 @@ Every schema in this repo is published as a `com.atproto.lexicon.schema` record 
 
 **Collaborative projects**
 
-| NSID                         | Purpose                                 |
-| ---------------------------- | --------------------------------------- |
-| `id.sifa.project.self`       | Collaborative project record            |
-| `id.sifa.project.member`     | Project team membership invitation      |
-| `id.sifa.project.membership` | Acceptance of a project team invitation |
+| NSID                         | Purpose                                |
+| ---------------------------- | -------------------------------------- |
+| `id.sifa.project.self`       | Collaborative project record           |
+| `id.sifa.project.member`     | Deprecated. Use `id.sifa.confirmation` |
+| `id.sifa.project.membership` | Deprecated. Use `id.sifa.confirmation` |
+
+Project members are named inline on `id.sifa.profile.project` and affirm the claim
+with an `id.sifa.confirmation` record in their own repository.
 
 **Social interactions**
 
-| NSID                               | Purpose                          |
-| ---------------------------------- | -------------------------------- |
-| `id.sifa.endorsement`              | Skill endorsements               |
-| `id.sifa.endorsement.confirmation` | Endorsement confirmations        |
-| `id.sifa.meeting`                  | Face-to-face meeting attestation |
+| NSID                               | Purpose                                          |
+| ---------------------------------- | ------------------------------------------------ |
+| `id.sifa.endorsement`              | Skill endorsements                               |
+| `id.sifa.endorsement.confirmation` | Endorsement confirmations                        |
+| `id.sifa.confirmation`             | Affirmation that a record naming you is accurate |
+| `id.sifa.meeting`                  | Face-to-face meeting attestation                 |
 
 **OAuth permission sets**
 

--- a/lexicons/id/sifa/authProfileAccess.json
+++ b/lexicons/id/sifa/authProfileAccess.json
@@ -25,6 +25,7 @@
             "id.sifa.profile.language",
             "id.sifa.endorsement",
             "id.sifa.endorsement.confirmation",
+            "id.sifa.confirmation",
             "id.sifa.graph.follow"
           ]
         }

--- a/lexicons/id/sifa/confirmation.json
+++ b/lexicons/id/sifa/confirmation.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.confirmation",
-  "description": "Confirmation that a record naming you is accurate. Lives in the PDS of the person who was named, never in the claimer's. One record type serves every people-link Sifa supports: co-speaker credits on a presentation delivery, membership of a project, and further relations as they are added. The claim itself is public in the claimer's repository from the moment it is written, before and regardless of any confirmation. What confirmation changes is display: an unconfirmed claim renders without the named person's display name, avatar, or profile link, and never appears on their own profile.",
+  "description": "Confirmation that a record naming you is accurate. Lives in the PDS of the person who was named, never in the claimer's. One record type serves every people-link Sifa supports: co-speaker credits on a presentation delivery, membership of a project, and further relations as they are added. The claim itself is public in the claimer's repository from the moment it is written, before and regardless of any confirmation. What confirmation changes is display: an unconfirmed claim renders without the named person's display name, avatar, or profile link. Confirmation does not put the claimer's record on the named person's profile, and consumers must not render it there. That record belongs to the claimer, who can edit or rename it at will; a profile shows only records its owner controls.",
   "defs": {
     "main": {
       "type": "record",
@@ -20,6 +20,12 @@
             "type": "ref",
             "ref": "id.sifa.defs#confirmationRelation",
             "description": "What is being confirmed. Open set, so a consumer that does not recognise the relation can still tell that the named person affirmed something."
+          },
+          "subjectName": {
+            "type": "string",
+            "maxGraphemes": 300,
+            "maxLength": 3000,
+            "description": "Name or title the subject record carried at confirmation time: the project name, the presentation title, and so on. Stored here, in the confirming person's repository, so the claimer cannot alter it. Lets a consumer detect that the claim has drifted since it was affirmed, and flag or withdraw the confirmation when the subject is later renamed into something the person never agreed to."
           },
           "createdAt": {
             "type": "string",

--- a/lexicons/id/sifa/confirmation.json
+++ b/lexicons/id/sifa/confirmation.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.confirmation",
+  "description": "Confirmation that a record naming you is accurate. Lives in the PDS of the person who was named, never in the claimer's. One record type serves every people-link Sifa supports: co-speaker credits on a presentation delivery, membership of a project, and further relations as they are added. The claim itself is public in the claimer's repository from the moment it is written, before and regardless of any confirmation. What confirmation changes is display: an unconfirmed claim renders without the named person's display name, avatar, or profile link, and never appears on their own profile.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record affirming that the referenced record correctly names the author of this record.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "relation", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef to the record that names you. Deliberately unconstrained by collection, so the same record type confirms a co-speaker credit, a project membership, or any later relation. Resolve by AT-URI: the CID is an integrity hint pinning the version seen at confirmation time, and must not be used as a join key, because the claimer editing their record changes its CID without invalidating the confirmation."
+          },
+          "relation": {
+            "type": "ref",
+            "ref": "id.sifa.defs#confirmationRelation",
+            "description": "What is being confirmed. Open set, so a consumer that does not recognise the relation can still tell that the named person affirmed something."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this confirmation was created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -570,6 +570,47 @@
       "description": "Project is archived and no longer active."
     },
 
+    "confirmationRelation": {
+      "type": "string",
+      "description": "What an id.sifa.confirmation record affirms. Open set.",
+      "knownValues": ["id.sifa.defs#coSpeaker", "id.sifa.defs#projectMember"]
+    },
+    "coSpeaker": {
+      "type": "token",
+      "description": "The named person presented alongside the claimer at the referenced id.sifa.profile.presentationDelivery occasion."
+    },
+    "projectMember": {
+      "type": "token",
+      "description": "The named person worked on the referenced id.sifa.profile.project."
+    },
+    "projectMemberRef": {
+      "type": "object",
+      "description": "Another person named as a member of a project. A claim by the record author, not a fact: it carries the named person's display name, avatar, and profile link only once they publish a matching id.sifa.confirmation.",
+      "required": ["did"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the person named as a project member. Any atproto account is allowed."
+        },
+        "role": {
+          "type": "string",
+          "description": "Role the named person held on the project. Display only: it grants no write access to the project record, which lives in the author's repository.",
+          "knownValues": [
+            "id.sifa.defs#projectOwner",
+            "id.sifa.defs#projectCore",
+            "id.sifa.defs#projectContributor"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "maxGraphemes": 128,
+          "maxLength": 1280,
+          "description": "Optional title within the project (e.g. 'Lead Designer', 'Backend Engineer')."
+        }
+      }
+    },
+
     "externalRecordRef": {
       "type": "object",
       "description": "A reference to a record in another repository or lexicon by AT-URI. The CID is optional: it pins a specific version as an integrity hint, but consumers should resolve the AT-URI live so the reference tracks edits to the target.",

--- a/lexicons/id/sifa/profile/project.json
+++ b/lexicons/id/sifa/profile/project.json
@@ -32,7 +32,7 @@
           "projectRef": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "Reference to the first-class id.sifa.project.self record, if this personal project entry corresponds to a collaborative project."
+            "description": "Reference to the same project as recorded elsewhere: another person's id.sifa.profile.project entry for the work you shared, or a first-class id.sifa.project.self record. Set when you were named as a member of someone else's entry and keep your own version of it, so consumers can tell the two describe one project instead of showing it twice."
           },
           "position": {
             "type": "ref",
@@ -46,7 +46,7 @@
               "type": "ref",
               "ref": "id.sifa.defs#projectMemberRef"
             },
-            "description": "Other people who worked on this project. Each entry is a claim by the record author and is not self-verifying: the named person supplies the other half by publishing an id.sifa.confirmation record whose subject is this record and whose relation is id.sifa.defs#projectMember. Until they do, consumers must render the entry without their display name, avatar, or profile link, and must not show the project on their profile."
+            "description": "Other people who worked on this project. Each entry is a claim by the record author and is not self-verifying: the named person supplies the other half by publishing an id.sifa.confirmation record whose subject is this record and whose relation is id.sifa.defs#projectMember. Until they do, consumers must render the entry without their display name, avatar, or profile link. Confirming never puts this record on the named person's profile: it lives in the author's repository and the author can rename it at any time. A named person who wants the project on their profile keeps their own id.sifa.profile.project record and points its projectRef here."
           },
           "startedAt": {
             "type": "string",

--- a/lexicons/id/sifa/profile/project.json
+++ b/lexicons/id/sifa/profile/project.json
@@ -39,6 +39,15 @@
             "ref": "com.atproto.repo.strongRef",
             "description": "Reference to the associated id.sifa.profile.position record, if applicable."
           },
+          "members": {
+            "type": "array",
+            "maxLength": 50,
+            "items": {
+              "type": "ref",
+              "ref": "id.sifa.defs#projectMemberRef"
+            },
+            "description": "Other people who worked on this project. Each entry is a claim by the record author and is not self-verifying: the named person supplies the other half by publishing an id.sifa.confirmation record whose subject is this record and whose relation is id.sifa.defs#projectMember. Until they do, consumers must render the entry without their display name, avatar, or profile link, and must not show the project on their profile."
+          },
           "startedAt": {
             "type": "string",
             "description": "Project start date in YYYY-MM or YYYY-MM-DD format."

--- a/lexicons/id/sifa/project/member.json
+++ b/lexicons/id/sifa/project/member.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.project.member",
-  "description": "An invitation to join a project team, written by a project owner in their PDS. The invited user must create a corresponding id.sifa.project.membership record to confirm. Both records existing = confirmed team member.",
+  "description": "DEPRECATED, never implemented. An invitation to join a project team, written by a project owner in their PDS. Superseded by naming members inline on id.sifa.profile.project and having them affirm it with a generic id.sifa.confirmation record, which serves every people-link relation rather than only projects. Retained so the published schema record keeps resolving; write id.sifa.confirmation instead.",
   "defs": {
     "main": {
       "type": "record",

--- a/lexicons/id/sifa/project/membership.json
+++ b/lexicons/id/sifa/project/membership.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
   "id": "id.sifa.project.membership",
-  "description": "Acceptance of a project team invitation. Written by the invited user in their own PDS. References the id.sifa.project.member invitation record. Both records existing = confirmed team member. Either party can delete their record to revoke membership.",
+  "description": "DEPRECATED, never implemented. Acceptance of an id.sifa.project.member invitation, written by the invited user in their own PDS. Superseded by the generic id.sifa.confirmation record, which affirms any record naming you rather than project invitations alone. Retained so the published schema record keeps resolving; write id.sifa.confirmation instead.",
   "defs": {
     "main": {
       "type": "record",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -922,6 +922,19 @@ describe('id.sifa.confirmation lexicon', () => {
     expect(properties?.createdAt?.format).toBe('datetime');
   });
 
+  // Without a snapshot, a claimer can rename "Volunteer bake sale" to anything
+  // they like after you confirm and your record still vouches for it. Mirrors
+  // skillName on id.sifa.endorsement, which exists for the same reason.
+  it('subjectName snapshots what was confirmed', () => {
+    expect(properties?.subjectName?.type).toBe('string');
+    expect(properties?.subjectName?.maxGraphemes).toBe(300);
+    expect(required).not.toContain('subjectName');
+  });
+
+  it('subjectName description explains the drift check it enables', () => {
+    expect(properties?.subjectName?.description ?? '').toMatch(/renamed|changed|drift/i);
+  });
+
   // Third-party implementers need to know the claim is readable from the
   // claimer's repo before anyone confirms it. That is inherent to atproto and
   // should not be a surprise.
@@ -995,6 +1008,17 @@ describe('id.sifa.profile.project members field', () => {
 
   it('members caps at 50', () => {
     expect(properties?.members?.maxLength).toBe(50);
+  });
+
+  // A named person's own profile must never render a record from someone
+  // else's repo: the author could rename it to anything at any time. They keep
+  // their own entry and link it back with projectRef.
+  it('members description rules out rendering this record on the named person profile', () => {
+    expect(properties?.members?.description ?? '').toMatch(/own record|their own/i);
+  });
+
+  it('projectRef accepts another persons profile.project, not only project.self', () => {
+    expect(properties?.projectRef?.description ?? '').toContain('id.sifa.profile.project');
   });
 
   // Naming someone is a claim, not a fact. The lexicon has to say so, because

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -885,6 +885,138 @@ describe('id.sifa.getProfileView query lexicon', () => {
   });
 });
 
+describe('id.sifa.confirmation lexicon', () => {
+  const confirmation = recordLexicons.find((l) => l.doc.id === 'id.sifa.confirmation');
+  const properties = confirmation?.doc.defs.main.record?.properties;
+  const required = confirmation?.doc.defs.main.record?.required ?? [];
+
+  it('exists as a tid-keyed record', () => {
+    expect(confirmation).toBeDefined();
+    expect(confirmation!.doc.defs.main.type).toBe('record');
+    expect(confirmation!.doc.defs.main.key).toBe('tid');
+  });
+
+  it('requires subject, relation, and createdAt', () => {
+    expect(required).toEqual(['subject', 'relation', 'createdAt']);
+  });
+
+  // The subject strongRef deliberately carries no collection constraint: one
+  // confirmation record type serves co-speaker credits, project membership,
+  // and every people-link section we add later.
+  it('subject is a com.atproto.repo.strongRef', () => {
+    expect(properties?.subject?.type).toBe('ref');
+    expect(properties?.subject?.ref).toBe('com.atproto.repo.strongRef');
+  });
+
+  it('subject description says the CID is an integrity hint, not a join key', () => {
+    expect(properties?.subject?.description ?? '').toMatch(/AT-URI/);
+    expect(properties?.subject?.description ?? '').toMatch(/integrity hint/i);
+  });
+
+  it('relation references id.sifa.defs#confirmationRelation', () => {
+    expect(properties?.relation?.type).toBe('ref');
+    expect(properties?.relation?.ref).toBe('id.sifa.defs#confirmationRelation');
+  });
+
+  it('createdAt uses datetime format', () => {
+    expect(properties?.createdAt?.format).toBe('datetime');
+  });
+
+  // Third-party implementers need to know the claim is readable from the
+  // claimer's repo before anyone confirms it. That is inherent to atproto and
+  // should not be a surprise.
+  it('description warns that the claim is public before confirmation', () => {
+    expect(confirmation!.doc.description ?? '').toMatch(/public/i);
+    expect(confirmation!.doc.description ?? '').toMatch(/before/i);
+  });
+});
+
+describe('id.sifa.defs confirmation additions', () => {
+  interface DefsDoc {
+    defs: Record<
+      string,
+      {
+        type: string;
+        description?: string;
+        knownValues?: string[];
+        required?: string[];
+        properties?: Record<
+          string,
+          { type: string; format?: string; knownValues?: string[]; maxGraphemes?: number }
+        >;
+      }
+    >;
+  }
+  const defs = JSON.parse(readFileSync(join(LEXICONS_DIR, 'defs.json'), 'utf-8')) as DefsDoc;
+
+  it('confirmationRelation is a string def naming the two shipped relations', () => {
+    expect(defs.defs.confirmationRelation?.type).toBe('string');
+    expect(defs.defs.confirmationRelation?.knownValues).toEqual([
+      'id.sifa.defs#coSpeaker',
+      'id.sifa.defs#projectMember',
+    ]);
+  });
+
+  it.each(['coSpeaker', 'projectMember'])('declares the %s token', (token) => {
+    expect(defs.defs[token]?.type).toBe('token');
+    expect(defs.defs[token]?.description?.length).toBeGreaterThan(0);
+  });
+
+  it('projectMemberRef requires only a did', () => {
+    expect(defs.defs.projectMemberRef?.type).toBe('object');
+    expect(defs.defs.projectMemberRef?.required).toEqual(['did']);
+    expect(defs.defs.projectMemberRef?.properties?.did?.type).toBe('string');
+    expect(defs.defs.projectMemberRef?.properties?.did?.format).toBe('did');
+  });
+
+  it('projectMemberRef.role reuses the projectRole known values', () => {
+    expect(defs.defs.projectMemberRef?.properties?.role?.knownValues).toEqual(
+      defs.defs.projectRole?.knownValues,
+    );
+  });
+
+  it('projectMemberRef.title is capped free text', () => {
+    expect(defs.defs.projectMemberRef?.properties?.title?.type).toBe('string');
+    expect(defs.defs.projectMemberRef?.properties?.title?.maxGraphemes).toBe(128);
+  });
+});
+
+describe('id.sifa.profile.project members field', () => {
+  const project = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.project');
+  const properties = project?.doc.defs.main.record?.properties;
+  const required = project?.doc.defs.main.record?.required ?? [];
+
+  it('members is an optional array of id.sifa.defs#projectMemberRef', () => {
+    expect(properties?.members?.type).toBe('array');
+    expect(properties?.members?.items?.type).toBe('ref');
+    expect(properties?.members?.items?.ref).toBe('id.sifa.defs#projectMemberRef');
+    expect(required).not.toContain('members');
+  });
+
+  it('members caps at 50', () => {
+    expect(properties?.members?.maxLength).toBe(50);
+  });
+
+  // Naming someone is a claim, not a fact. The lexicon has to say so, because
+  // an implementer reading only the schema would otherwise render the DID as
+  // an established team member.
+  it('members description points at id.sifa.confirmation for the consent half', () => {
+    expect(properties?.members?.description ?? '').toContain('id.sifa.confirmation');
+  });
+});
+
+describe('retired collaborative project lexicons', () => {
+  it.each(['id.sifa.project.member', 'id.sifa.project.membership'])(
+    '%s is marked deprecated in favour of id.sifa.confirmation',
+    (nsid) => {
+      const lexicon = recordLexicons.find((l) => l.doc.id === nsid);
+      expect(lexicon).toBeDefined();
+      expect(lexicon!.doc.description).toMatch(/DEPRECATED/);
+      expect(lexicon!.doc.description).toContain('id.sifa.confirmation');
+    },
+  );
+});
+
 describe('openToWorkStatus commissions token', () => {
   interface DefsDoc {
     defs: {

--- a/well-known/activity-tiers.json
+++ b/well-known/activity-tiers.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://sifa.id/schemas/activity-tiers/v1.json",
   "version": "1.0.0",
-  "updated": "2026-05-28",
+  "updated": "2026-07-31",
   "tiers": {
     "creation": {
       "label": "Made",
@@ -296,6 +296,11 @@
       "app": "sifa",
       "notes": "Confirmation/acceptance of an endorsement received."
     },
+    "id.sifa.confirmation": {
+      "tier": "action",
+      "app": "sifa",
+      "notes": "Confirmation that a record naming the actor is accurate (co-speaker credit, project membership)."
+    },
     "id.sifa.graph.follow": { "tier": "action", "app": "sifa" },
     "id.sifa.graph.connection": {
       "tier": "creation",
@@ -303,8 +308,16 @@
       "notes": "Mutual professional connection record."
     },
     "id.sifa.project.self": { "tier": "creation", "app": "sifa" },
-    "id.sifa.project.member": { "tier": "creation", "app": "sifa" },
-    "id.sifa.project.membership": { "tier": "creation", "app": "sifa" },
+    "id.sifa.project.member": {
+      "tier": "creation",
+      "app": "sifa",
+      "notes": "Deprecated, never implemented. Superseded by id.sifa.confirmation."
+    },
+    "id.sifa.project.membership": {
+      "tier": "creation",
+      "app": "sifa",
+      "notes": "Deprecated, never implemented. Superseded by id.sifa.confirmation."
+    },
     "id.sifa.meeting": { "tier": "creation", "app": "sifa" },
     "id.sifa.authProfile": { "tier": "filtered", "app": "sifa", "notes": "OAuth scope record." },
     "id.sifa.authProfileAccess": {


### PR DESCRIPTION
First repo of singi-labs/sifa-workspace#353. Lexicons only; SDK, API, and web follow.

## What

**New `id.sifa.confirmation`** -- one generic record affirming that a record naming you is accurate. Lives in the named person's PDS. The `subject` strongRef deliberately carries no collection constraint, so the same record type serves co-speaker credits, project membership, and whatever people-link sections come next (co-authors on publications, collaborators on involvement) without minting a new NSID each time.

**`id.sifa.profile.project.members`** -- optional array of the new `defs#projectMemberRef` (`did`, optional `role`, optional `title`), max 50. Mirrors how `coSpeakers` already works: the claim is embedded on the author's own record, the consent lives in the named person's repo.

**`defs.json`** gains `confirmationRelation` (+ `coSpeaker` / `projectMember` tokens) and `projectMemberRef`.

**Deprecates `id.sifa.project.member` and `id.sifa.project.membership`** -- written for the never-implemented `id.sifa.project.self`, zero code anywhere, subsumed by the generic confirmation. The JSON stays so the published `com.atproto.lexicon.schema` records keep resolving; only the descriptions change.

## Three decisions worth reviewing

**Resolve the subject by AT-URI. The CID is an integrity hint, not a join key.** The claimer editing their project changes its CID; a CID join would orphan every confirmation on every edit. Already the shipped precedent -- `sifa-api/src/routes/endorsement.ts` joins confirmation to endorsement on a reconstructed AT-URI and never compares `skillCid`.

**`subjectName` snapshots what was confirmed.** Without it, a claimer can rename "Volunteer bake sale" into anything after you confirm and your record still vouches for it. Stored in the confirming person's repo where the claimer cannot reach it, so a consumer can detect drift and flag or withdraw. Directly mirrors `skillName` on `id.sifa.endorsement`.

**Confirming does not put the claimer's record on the named person's profile,** and the descriptions say so. That record lives in the claimer's repository and they can rename it at will -- a direct route to unwanted content on someone else's CV. A named person who wants the project on their profile keeps their own `profile.project` record and points its `projectRef` at the claimer's. `projectRef` was declared for `project.self` and wired to nothing; widened here to cover another person's `profile.project` entry, which is what the dedupe actually needs.

**`role` is display only.** It cannot grant write access to a record living in someone else's repository, and the description states that rather than leaving it implied.

## Rendering contract, stated in the schemas

An unconfirmed claim renders without the named person's display name, avatar, or profile link. The lexicon descriptions carry this because an implementer reading only the schema would otherwise render a bare DID as an established team member. The claim itself is public in the claimer's repo from the moment it is written -- inherent to atproto, and called out in the record description so it is not a surprise.

## Tests

375 passing, 22 new assertions covering the record shape, the required trio, the `subjectName` snapshot, the defs additions, the `members` array, the `projectRef` widening, and the deprecation notices.

Refs singi-labs/sifa-workspace#353
