### PR TITLE
feat(lexicons): add sameAs for the same thing recorded by someone else

### DIFF
--- a/lexicons/id/sifa/profile/presentationDelivery.json
+++ b/lexicons/id/sifa/profile/presentationDelivery.json
@@ -16,6 +16,11 @@
             "ref": "id.sifa.defs#externalRecordRef",
             "description": "Optional reference to the id.sifa.profile.presentation (the content) delivered here. When set, title, duration, and audiences are taken from it."
           },
+          "sameAs": {
+            "type": "ref",
+            "ref": "id.sifa.defs#externalRecordRef",
+            "description": "The same session as recorded on another person's profile. Set when you keep your own entry for work someone else has also recorded, so consumers can tell the two describe one thing rather than showing it twice. Each side stays its own record: the other person cannot edit yours, and yours does not change theirs. Resolve by AT-URI, since they will keep editing their copy."
+          },
           "title": {
             "type": "string",
             "maxGraphemes": 300,

--- a/lexicons/id/sifa/profile/project.json
+++ b/lexicons/id/sifa/profile/project.json
@@ -32,12 +32,17 @@
           "projectRef": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "Reference to the same project as recorded elsewhere: another person's id.sifa.profile.project entry for the work you shared, or a first-class id.sifa.project.self record. Set when you were named as a member of someone else's entry and keep your own version of it, so consumers can tell the two describe one project instead of showing it twice."
+            "description": "Reference to the first-class id.sifa.project.self record this personal entry corresponds to, when there is one. A composition link, not a peer one: for the same project recorded on someone else's profile, see sameAs."
           },
           "position": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
             "description": "Reference to the associated id.sifa.profile.position record, if applicable."
+          },
+          "sameAs": {
+            "type": "ref",
+            "ref": "id.sifa.defs#externalRecordRef",
+            "description": "The same project as recorded on another person's profile. Set when you keep your own entry for work someone else has also recorded, so consumers can tell the two describe one thing rather than showing it twice. Each side stays its own record: the other person cannot edit yours, and yours does not change theirs. Resolve by AT-URI, since they will keep editing their copy."
           },
           "members": {
             "type": "array",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -1017,8 +1017,13 @@ describe('id.sifa.profile.project members field', () => {
     expect(properties?.members?.description ?? '').toMatch(/own record|their own/i);
   });
 
-  it('projectRef accepts another persons profile.project, not only project.self', () => {
-    expect(properties?.projectRef?.description ?? '').toContain('id.sifa.profile.project');
+  // projectRef is the hierarchical relation: this personal entry corresponds to
+  // a canonical id.sifa.project.self. Peer sameness moved to sameAs, because
+  // conflating the two left no name for it on presentationDelivery, where
+  // presentationRef already means "instance of that talk".
+  it('projectRef stays the hierarchical link to project.self', () => {
+    expect(properties?.projectRef?.description ?? '').toContain('id.sifa.project.self');
+    expect(properties?.projectRef?.description ?? '').not.toContain('another person');
   });
 
   // Naming someone is a claim, not a fact. The lexicon has to say so, because
@@ -1026,6 +1031,42 @@ describe('id.sifa.profile.project members field', () => {
   // an established team member.
   it('members description points at id.sifa.confirmation for the consent half', () => {
     expect(properties?.members?.description ?? '').toContain('id.sifa.confirmation');
+  });
+});
+
+describe('sameAs peer link', () => {
+  // One field name across every record type that can name another person, for
+  // the same reason id.sifa.confirmation is one record type: the relation is
+  // identical, and a per-collection name would be four spellings of it.
+  const withSameAs = ['id.sifa.profile.project', 'id.sifa.profile.presentationDelivery'] as const;
+
+  it.each(withSameAs)('%s declares an optional sameAs', (nsid) => {
+    const lexicon = recordLexicons.find((l) => l.doc.id === nsid);
+    const properties = lexicon?.doc.defs.main.record?.properties;
+    const required = lexicon?.doc.defs.main.record?.required ?? [];
+    expect(properties?.sameAs?.type).toBe('ref');
+    expect(properties?.sameAs?.ref).toBe('id.sifa.defs#externalRecordRef');
+    expect(required).not.toContain('sameAs');
+  });
+
+  // externalRecordRef rather than strongRef: the CID is an integrity hint and
+  // the reference must resolve live, because the other person edits their
+  // record without that invalidating the link.
+  it.each(withSameAs)('%s sameAs description says it is the same real thing', (nsid) => {
+    const lexicon = recordLexicons.find((l) => l.doc.id === nsid);
+    const description = lexicon?.doc.defs.main.record?.properties?.sameAs?.description ?? '';
+    expect(description).toMatch(/same/i);
+    expect(description).toMatch(/own/i);
+  });
+
+  // Composition, not sameness. A delivery is an instance of a talk; it is not
+  // another copy of one.
+  it('presentationDelivery keeps presentationRef for the parent talk', () => {
+    const lexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.presentationDelivery');
+    const description =
+      lexicon?.doc.defs.main.record?.properties?.presentationRef?.description ?? '';
+    expect(description).toContain('id.sifa.profile.presentation');
+    expect(description).not.toMatch(/same project|another person/i);
   });
 });
 


### PR DESCRIPTION
Prerequisite for follow-up 3 in singi-labs/sifa-workspace#353 (confirmed co-speakers keeping the talk on their own profile).

## Two relations, one field name

`projectRef` was documented as the link to a canonical `id.sifa.project.self`, then widened in #79 to also mean "another person's entry for the same work". Those are different relations:

| Relation | Meaning | Example |
|---|---|---|
| Composition | this record is an instance of that canonical thing | `presentationRef` -> parent talk, `projectRef` -> `project.self` |
| Peer sameness | my record and your record describe the same real thing | what confirming needs |

The tell is that the same trick cannot be repeated on `presentationDelivery`: `presentationRef` there already means "an instance of that talk", so peer sameness had nowhere to go. That is not a naming collision, it is the two relations being genuinely distinct.

So one generic `sameAs`, for the same reason `id.sifa.confirmation` is one record type rather than four. Publications and involvement can adopt it unchanged.

`projectRef` goes back to the composition link it was documented as.

## Shape

`externalRecordRef`, not `strongRef`. The CID has to be optional and advisory: the other person keeps editing their record, and that must not invalidate a link asserting the two describe one thing. `strongRef` requires a CID and reads as a version pin, which is the opposite of what this means.

## Nothing to migrate

Prod has `project_ref` set on **0 of 1309** projects, and the column that would carry it is not deployed yet. This is free now and would not be in a month.

## Tests

380 passing, 5 new: both records declare an optional `sameAs` of the right type, the descriptions say same-thing-but-your-own-record, `projectRef` is back to naming only `project.self`, and `presentationRef` still describes the parent talk.

Refs singi-labs/sifa-workspace#353