### PR TITLE
feat(lexicons): declare author and collaborator, add involvement collaborators

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -573,7 +573,12 @@
     "confirmationRelation": {
       "type": "string",
       "description": "What an id.sifa.confirmation record affirms. Open set.",
-      "knownValues": ["id.sifa.defs#coSpeaker", "id.sifa.defs#projectMember"]
+      "knownValues": [
+        "id.sifa.defs#coSpeaker",
+        "id.sifa.defs#projectMember",
+        "id.sifa.defs#author",
+        "id.sifa.defs#collaborator"
+      ]
     },
     "coSpeaker": {
       "type": "token",
@@ -582,6 +587,14 @@
     "projectMember": {
       "type": "token",
       "description": "The named person worked on the referenced id.sifa.profile.project."
+    },
+    "author": {
+      "type": "token",
+      "description": "The named person co-authored the referenced id.sifa.profile.publication."
+    },
+    "collaborator": {
+      "type": "token",
+      "description": "The named person worked alongside the claimer on the referenced id.sifa.profile.involvement."
     },
     "projectMemberRef": {
       "type": "object",

--- a/lexicons/id/sifa/profile/involvement.json
+++ b/lexicons/id/sifa/profile/involvement.json
@@ -58,11 +58,28 @@
             "type": "string",
             "description": "End date in YYYY-MM or YYYY-MM-DD format. Omit if ongoing."
           },
+          "collaborators": {
+            "type": "array",
+            "maxLength": 50,
+            "items": {
+              "type": "ref",
+              "ref": "id.sifa.defs#projectMemberRef"
+            },
+            "description": "Other people who worked on this alongside you. Each entry is a claim by the record author and is not self-verifying: the named person supplies the other half by publishing an id.sifa.confirmation record whose subject is this record and whose relation is id.sifa.defs#collaborator. Until they do, consumers must render the entry without their display name, avatar, or profile link. Confirming never puts this record on their profile: it lives in the author's repository and the author can rename it at any time."
+          },
+          "sameAs": {
+            "type": "ref",
+            "ref": "id.sifa.defs#externalRecordRef",
+            "description": "The same involvement as recorded on another person's profile. Set when you keep your own entry for work someone else has also recorded, so consumers can tell the two describe one thing rather than showing it twice. Each side stays its own record: the other person cannot edit yours, and yours does not change theirs. Resolve by AT-URI, since they will keep editing their copy."
+          },
           "links": {
             "type": "array",
             "maxLength": 50,
             "description": "Public artifacts proving the involvement (PRs, releases, talk recordings, published translations).",
-            "items": { "type": "ref", "ref": "id.sifa.defs#artifactLink" }
+            "items": {
+              "type": "ref",
+              "ref": "id.sifa.defs#artifactLink"
+            }
           },
           "entityRef": {
             "type": "string",
@@ -76,7 +93,10 @@
           },
           "skills": {
             "type": "array",
-            "items": { "type": "ref", "ref": "id.sifa.defs#skillRef" },
+            "items": {
+              "type": "ref",
+              "ref": "id.sifa.defs#skillRef"
+            },
             "description": "Skills demonstrated by this involvement. Each entry is a URI reference to an id.sifa.profile.skill record owned by the same DID.",
             "maxLength": 50
           },

--- a/lexicons/id/sifa/profile/publication.json
+++ b/lexicons/id/sifa/profile/publication.json
@@ -41,6 +41,11 @@
             "maxLength": 50000,
             "description": "Description or abstract."
           },
+          "sameAs": {
+            "type": "ref",
+            "ref": "id.sifa.defs#externalRecordRef",
+            "description": "The same publication as recorded on another person's profile. Set when you keep your own entry for work someone else has also recorded, so consumers can tell the two describe one thing rather than showing it twice. Each side stays its own record: the other person cannot edit yours, and yours does not change theirs. Resolve by AT-URI, since they will keep editing their copy."
+          },
           "authors": {
             "type": "array",
             "maxLength": 50,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@singi-labs/sifa-lexicons",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@atproto/lexicon": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singi-labs/sifa-lexicons",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "AT Protocol lexicon schemas and generated TypeScript types for Sifa professional profiles (id.sifa.*)",
   "type": "module",
   "license": "MIT",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -962,18 +962,23 @@ describe('id.sifa.defs confirmation additions', () => {
   }
   const defs = JSON.parse(readFileSync(join(LEXICONS_DIR, 'defs.json'), 'utf-8')) as DefsDoc;
 
-  it('confirmationRelation is a string def naming the two shipped relations', () => {
+  it('confirmationRelation names every shipped relation', () => {
     expect(defs.defs.confirmationRelation?.type).toBe('string');
     expect(defs.defs.confirmationRelation?.knownValues).toEqual([
       'id.sifa.defs#coSpeaker',
       'id.sifa.defs#projectMember',
+      'id.sifa.defs#author',
+      'id.sifa.defs#collaborator',
     ]);
   });
 
-  it.each(['coSpeaker', 'projectMember'])('declares the %s token', (token) => {
-    expect(defs.defs[token]?.type).toBe('token');
-    expect(defs.defs[token]?.description?.length).toBeGreaterThan(0);
-  });
+  it.each(['coSpeaker', 'projectMember', 'author', 'collaborator'])(
+    'declares the %s token',
+    (token) => {
+      expect(defs.defs[token]?.type).toBe('token');
+      expect(defs.defs[token]?.description?.length).toBeGreaterThan(0);
+    },
+  );
 
   it('projectMemberRef requires only a did', () => {
     expect(defs.defs.projectMemberRef?.type).toBe('object');
@@ -991,6 +996,54 @@ describe('id.sifa.defs confirmation additions', () => {
   it('projectMemberRef.title is capped free text', () => {
     expect(defs.defs.projectMemberRef?.properties?.title?.type).toBe('string');
     expect(defs.defs.projectMemberRef?.properties?.title?.maxGraphemes).toBe(128);
+  });
+});
+
+describe('id.sifa.profile.involvement collaborators field', () => {
+  const involvement = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.involvement');
+  const properties = involvement?.doc.defs.main.record?.properties;
+  const required = involvement?.doc.defs.main.record?.required ?? [];
+
+  // Same shape as project members, because it is the same relation: people you
+  // did this with. Reusing projectMemberRef rather than minting a parallel def
+  // that differs only in name.
+  it('collaborators is an optional array of id.sifa.defs#projectMemberRef', () => {
+    expect(properties?.collaborators?.type).toBe('array');
+    expect(properties?.collaborators?.items?.type).toBe('ref');
+    expect(properties?.collaborators?.items?.ref).toBe('id.sifa.defs#projectMemberRef');
+    expect(required).not.toContain('collaborators');
+  });
+
+  it('collaborators caps at 50', () => {
+    expect(properties?.collaborators?.maxLength).toBe(50);
+  });
+
+  it('collaborators description points at id.sifa.confirmation', () => {
+    expect(properties?.collaborators?.description ?? '').toContain('id.sifa.confirmation');
+  });
+
+  it('involvement declares sameAs, so a collaborator can keep their own entry', () => {
+    expect(properties?.sameAs?.ref).toBe('id.sifa.defs#externalRecordRef');
+    expect(required).not.toContain('sameAs');
+  });
+});
+
+describe('id.sifa.profile.publication authors are confirmable', () => {
+  const publication = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.publication');
+  const properties = publication?.doc.defs.main.record?.properties;
+
+  // The name is required and the DID optional on purpose: an ORCID import knows
+  // who wrote a paper without knowing whether they are on atproto at all.
+  it('an author needs a name and may carry a did', () => {
+    const authorDef = publication?.doc.defs.author as
+      | { required?: string[]; properties?: Record<string, { format?: string }> }
+      | undefined;
+    expect(authorDef?.required).toEqual(['name']);
+    expect(authorDef?.properties?.did?.format).toBe('did');
+  });
+
+  it('publication declares sameAs', () => {
+    expect(properties?.sameAs?.ref).toBe('id.sifa.defs#externalRecordRef');
   });
 });
 


### PR DESCRIPTION
The last two items on singi-labs/sifa-workspace#353.

## The author token was in use and never declared

`id.sifa.defs#author` has been written on live confirmation records since singi-labs/sifa-api#1086. The relation is an open set so it worked, but a token nobody can look up is a token nobody can implement against.

## Involvement collaborators

Reuses `projectMemberRef` rather than minting a parallel def differing only in name. It is the same relation, people you did this with, and involvement is the fourth record type to carry it.

The AppView side is mostly wiring now: `record_person_claims` takes a collection, and the inbox and confirm route both dispatch on one.

## sameAs on involvement and publication

So a confirmed collaborator or author can keep their own entry for the same work without it being a second, unrelated one. Project and presentationDelivery already had it; this finishes the set.

## Tests

388 passing, 12 new: the widened `confirmationRelation`, both new tokens, the collaborators array and its cap, the pointer to `id.sifa.confirmation`, `sameAs` on both records, and that a publication author still requires a name while the DID stays optional.

Refs singi-labs/sifa-workspace#353