### PR TITLE
feat(profile): add speakingEngagements to openTo

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -415,7 +415,8 @@
         "id.sifa.defs#boardPositions",
         "id.sifa.defs#mentoringOthers",
         "id.sifa.defs#beingMentored",
-        "id.sifa.defs#collaborations"
+        "id.sifa.defs#collaborations",
+        "id.sifa.defs#speakingEngagements"
       ]
     },
     "fullTimeRoles": {
@@ -438,6 +439,10 @@
     "mentoringOthers": { "type": "token", "description": "Open to mentoring others." },
     "beingMentored": { "type": "token", "description": "Open to being mentored." },
     "collaborations": { "type": "token", "description": "Open to project collaborations." },
+    "speakingEngagements": {
+      "type": "token",
+      "description": "Open to speaking engagements (talks, panels, keynotes, workshops)."
+    },
 
     "externalPlatform": {
       "type": "string",

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -80,7 +80,8 @@
                 "id.sifa.defs#boardPositions",
                 "id.sifa.defs#mentoringOthers",
                 "id.sifa.defs#beingMentored",
-                "id.sifa.defs#collaborations"
+                "id.sifa.defs#collaborations",
+                "id.sifa.defs#speakingEngagements"
               ]
             },
             "description": "Types of opportunities the user is open to. Empty array or omitted means not actively seeking."

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -1188,3 +1188,43 @@ describe('openToWorkStatus commissions token', () => {
     );
   });
 });
+
+describe('openToWorkStatus speakingEngagements token', () => {
+  interface DefsDoc {
+    defs: {
+      openToWorkStatus: { knownValues: string[] };
+      speakingEngagements?: { type: string; description: string };
+    };
+  }
+  interface SelfDoc {
+    defs: {
+      main: {
+        record: {
+          properties: {
+            openTo: { items: { knownValues: string[] } };
+          };
+        };
+      };
+    };
+  }
+  const defs = JSON.parse(readFileSync(join(LEXICONS_DIR, 'defs.json'), 'utf-8')) as DefsDoc;
+  const self = JSON.parse(
+    readFileSync(join(LEXICONS_DIR, 'profile', 'self.json'), 'utf-8'),
+  ) as SelfDoc;
+
+  it('defs.json declares a speakingEngagements token', () => {
+    expect(defs.defs.speakingEngagements).toBeDefined();
+    expect(defs.defs.speakingEngagements?.type).toBe('token');
+    expect(defs.defs.speakingEngagements?.description).toMatch(/speak/i);
+  });
+
+  it('openToWorkStatus knownValues includes id.sifa.defs#speakingEngagements', () => {
+    expect(defs.defs.openToWorkStatus.knownValues).toContain('id.sifa.defs#speakingEngagements');
+  });
+
+  it('profile/self.json openTo knownValues includes id.sifa.defs#speakingEngagements', () => {
+    expect(self.defs.main.record.properties.openTo.items.knownValues).toContain(
+      'id.sifa.defs#speakingEngagements',
+    );
+  });
+});


### PR DESCRIPTION
Adds `id.sifa.defs#speakingEngagements` so a profile can advertise that its owner is available to speak.

Requested by Teon Brooks in https://bsky.app/profile/teonbrooks.com/post/3ms767kpzgc23, filed as singi-labs/sifa-workspace#359.

## Why openTo rather than a new field

Speaking availability is a standing signal, the same shape as `mentoringOthers` and `collaborations`. It is not a job hunt, and it is not a section. `openTo` already carries exactly this kind of statement, and it already has availability-window fields (`availableFrom` / `availableUntil`) that apply for free.

## Changes

- `defs.json`: new `speakingEngagements` token, added to `openToWorkStatus.knownValues`.
- `profile/self.json`: same token added to `openTo.items.knownValues` (the list is duplicated inline there; an existing test enforces the two stay in sync).
- Tests mirroring the `commissions` precedent.

## Compatibility

`openToWorkStatus` is an open enum, so this is purely additive. No existing record or consumer changes behaviour.

## Not in this PR

SDK types, formatter label, and the sifa-web editor option. Those follow once this publishes, per the SDK-first rule.

## Verification

`npm test` 391 passed, plus lint, typecheck, and format:check clean. `npm run generate` produces no diff, since knownValues do not affect the generated types.
