### PR TITLE
feat(profile): add board and advisory employment types

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -19,7 +19,10 @@
         "id.sifa.defs#apprenticeship",
         "id.sifa.defs#fellowship",
         "id.sifa.defs#trainee",
-        "id.sifa.defs#volunteer"
+        "id.sifa.defs#volunteer",
+        "id.sifa.defs#boardMember",
+        "id.sifa.defs#boardObserver",
+        "id.sifa.defs#advisor"
       ]
     },
     "fullTime": {
@@ -73,6 +76,18 @@
     "volunteer": {
       "type": "token",
       "description": "Volunteer work (when used as employment type)."
+    },
+    "boardMember": {
+      "type": "token",
+      "description": "Seat on a board of directors or supervisory board, carrying a vote and fiduciary duty. Usually not employment, in the same way volunteer is not."
+    },
+    "boardObserver": {
+      "type": "token",
+      "description": "Board observer seat: attends and is informed but holds no vote. The common shape of an investor seat, kept distinct so it does not read as directorship."
+    },
+    "advisor": {
+      "type": "token",
+      "description": "Advisory role, paid or unpaid, without a board seat or line responsibility."
     },
 
     "workplaceType": {

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -57,8 +57,27 @@
               "id.sifa.defs#apprenticeship",
               "id.sifa.defs#fellowship",
               "id.sifa.defs#trainee",
-              "id.sifa.defs#volunteer"
+              "id.sifa.defs#volunteer",
+              "id.sifa.defs#boardMember",
+              "id.sifa.defs#boardObserver",
+              "id.sifa.defs#advisor"
             ]
+          },
+          "onBehalfOf": {
+            "type": "string",
+            "maxGraphemes": 256,
+            "maxLength": 2560,
+            "description": "Name of the party this role is held on behalf of, when the person represents someone else — most often a fund whose board seat this is. A disclosure, not a role type. Omit for independent seats."
+          },
+          "onBehalfOfDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the represented party's ATproto account, if one exists. May resolve to an organization or to a person (e.g. a family-office principal)."
+          },
+          "onBehalfOfEntityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the represented party selected from a resolver dropdown: a Wikidata Q-ID URI, a ROR URI, or an LEI URI. Absent for free-text entries."
           },
           "workplaceType": {
             "type": "string",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -104,6 +104,7 @@ const USER_TEXT_FIELDS = new Set([
   'description',
   'company',
   'companyName',
+  'onBehalfOf',
   'title',
   'subtitle',
   'subCategory',
@@ -1226,5 +1227,92 @@ describe('openToWorkStatus speakingEngagements token', () => {
     expect(self.defs.main.record.properties.openTo.items.knownValues).toContain(
       'id.sifa.defs#speakingEngagements',
     );
+  });
+});
+
+describe('Board and advisory employment types', () => {
+  interface DefsDoc {
+    defs: Record<
+      string,
+      {
+        type: string;
+        description?: string;
+        knownValues?: string[];
+      }
+    >;
+  }
+  const defs = JSON.parse(readFileSync(join(LEXICONS_DIR, 'defs.json'), 'utf-8')) as DefsDoc;
+  const positionLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.position');
+  const properties = positionLexicon?.doc.defs.main.record?.properties;
+  const employmentType = properties?.employmentType as { knownValues?: string[] } | undefined;
+
+  // The three roles are career-shaped -- a title, duties, a term -- so they belong on
+  // position rather than on the investment record. See sifa-lexicons#86.
+  it.each(['boardMember', 'boardObserver', 'advisor'])('declares the %s token', (token) => {
+    expect(defs.defs[token]?.type).toBe('token');
+    expect(defs.defs[token]?.description?.length).toBeGreaterThan(0);
+  });
+
+  it('defs.employmentType knownValues include the three new tokens', () => {
+    expect(defs.defs.employmentType?.knownValues).toContain('id.sifa.defs#boardMember');
+    expect(defs.defs.employmentType?.knownValues).toContain('id.sifa.defs#boardObserver');
+    expect(defs.defs.employmentType?.knownValues).toContain('id.sifa.defs#advisor');
+  });
+
+  it('position.employmentType knownValues stay in sync with defs.json employmentType', () => {
+    expect([...(employmentType?.knownValues ?? [])].sort()).toEqual(
+      [...(defs.defs.employmentType?.knownValues ?? [])].sort(),
+    );
+  });
+
+  // A non-executive director is not an employee, and neither is a volunteer -- the field
+  // has never been payroll-only. Kept as-is rather than renamed: a breaking rename buys
+  // nothing for users.
+  it('boardObserver description distinguishes it from boardMember by the absence of a vote', () => {
+    expect(defs.defs.boardObserver?.description).toMatch(/observ|no vote|non-voting/i);
+    expect(defs.defs.boardObserver?.description).not.toBe(defs.defs.boardMember?.description);
+  });
+
+  it('the existing employment types are preserved', () => {
+    for (const token of ['fullTime', 'partTime', 'contract', 'freelance', 'volunteer']) {
+      expect(defs.defs.employmentType?.knownValues).toContain(`id.sifa.defs#${token}`);
+    }
+  });
+});
+
+describe('Position onBehalfOf field', () => {
+  const positionLexicon = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.position');
+  const properties = positionLexicon?.doc.defs.main.record?.properties;
+  const required = positionLexicon?.doc.defs.main.record?.required ?? [];
+
+  // A board seat held as a fund's representative is a disclosure, not a role type: the
+  // person answers to a third party. Independent seats simply omit it.
+  it('onBehalfOf exists as an optional string with a grapheme cap', () => {
+    expect(properties?.onBehalfOf).toBeDefined();
+    expect(properties?.onBehalfOf?.type).toBe('string');
+    expect(properties?.onBehalfOf?.maxGraphemes).toBe(256);
+    expect(required).not.toContain('onBehalfOf');
+  });
+
+  // The referent is usually an organization but can be a person (a family-office
+  // principal), and a DID does not distinguish the two, so the field stays permissive.
+  it('onBehalfOfDid is an optional did-format string', () => {
+    expect(properties?.onBehalfOfDid?.type).toBe('string');
+    expect(properties?.onBehalfOfDid?.format).toBe('did');
+    expect(required).not.toContain('onBehalfOfDid');
+  });
+
+  it('onBehalfOfEntityRef is an optional uri-format string', () => {
+    expect(properties?.onBehalfOfEntityRef?.type).toBe('string');
+    expect(properties?.onBehalfOfEntityRef?.format).toBe('uri');
+    expect(required).not.toContain('onBehalfOfEntityRef');
+  });
+
+  it('onBehalfOf description explains the representation disclosure', () => {
+    expect(properties?.onBehalfOf?.description).toMatch(/behalf|represent/i);
+  });
+
+  it('position required fields are unchanged (backward compatible)', () => {
+    expect(required).toEqual(['title', 'startedAt', 'createdAt']);
   });
 });


### PR DESCRIPTION
Closes #86.

Board seats and advisory roles had nowhere to live. They are career-shaped — a title, duties, a term, and a counterparty who can attest them — so they belong on `position`, not on a capital record. The sibling `id.sifa.profile.investment` work covers money-in only.

## Changes

**`defs.json`** — three new tokens, added to `employmentType.knownValues`:

- `boardMember` — vote and fiduciary duty
- `boardObserver` — attends, no vote. Kept distinct because conflating it with `boardMember` overstates the person's authority, and an observer seat is the standard shape of an investor seat
- `advisor` — paid or unpaid, no board seat, no line responsibility

**`profile/position.json`** — same three values on the inline `employmentType` enum, plus an optional disclosure triple:

- `onBehalfOf` (256 graphemes), `onBehalfOfDid` (did), `onBehalfOfEntityRef` (uri)

A seat held as a fund's representative means the person answers to a third party. That is a disclosure, not a role type, so it is a separate optional field rather than more enum values. The referent is usually an organization but can be a person (a family-office principal) and a DID does not distinguish the two, so the field stays permissive.

## Notes

- `employmentType` is a mild misnomer for a non-executive director, who is normally not an employee. It already holds `volunteer`, so it was never payroll-only. Renaming a shipped lexicon field is breaking and buys users nothing, so the name stays.
- Backward compatible: `required` is unchanged (`title`, `startedAt`, `createdAt`), and all existing employment types are preserved — asserted by test.
- The two `employmentType` enums (defs and position) are now held in sync by a test, following the existing `openTo`/`openToWorkStatus` precedent.
- **Not reachable from import.** `mapPositionsCsv` is a 1:1 passthrough that does not set `employmentType` at all, and LinkedIn's Positions.csv carries no column separating a board seat from a job. Any split would be title-string heuristics, and a wrong split corrupts real history. These values are manual entry only, deliberately.
- `onBehalfOf` added to the test suite's `USER_TEXT_FIELDS`, so the generic grapheme-cap check covers it.

## Tests

10 new assertions, written before the schema change (red → green). 404 passing. `generate`, `typecheck`, `lint`, `format` all clean.

Decision doc: `decisions/2026-08-06-investment-records.md` in the Sifa workspace.
