### PR TITLE
feat(profile): add id.sifa.profile.investment

### DIFF
--- a/lexicons/id/sifa/defs.json
+++ b/lexicons/id/sifa/defs.json
@@ -770,6 +770,108 @@
       "description": "Other uncompensated involvement."
     },
 
+    "investmentRole": {
+      "type": "string",
+      "description": "How the capital went in. General partner is deliberately absent: running a fund is a role, recorded as an id.sifa.profile.position, and a partner's own commitment to their fund is a limitedPartner entry against that fund.",
+      "knownValues": [
+        "id.sifa.defs#angelInvestment",
+        "id.sifa.defs#syndicateInvestment",
+        "id.sifa.defs#limitedPartner",
+        "id.sifa.defs#otherInvestment"
+      ]
+    },
+    "angelInvestment": {
+      "type": "token",
+      "description": "Direct investment in the person's own name, with the person choosing the deal."
+    },
+    "syndicateInvestment": {
+      "type": "token",
+      "description": "Investment in a deal led by someone else, made through a per-deal pooled vehicle."
+    },
+    "limitedPartner": {
+      "type": "token",
+      "description": "Capital committed to a fund rather than to a company. The person does not choose the fund's deals, and the named entity is the fund itself."
+    },
+    "otherInvestment": {
+      "type": "token",
+      "description": "A capital position that fits none of the above."
+    },
+
+    "investmentStage": {
+      "type": "string",
+      "description": "The company's funding stage at the time the investment was made, not its stage today.",
+      "knownValues": [
+        "id.sifa.defs#stagePreSeed",
+        "id.sifa.defs#stageSeed",
+        "id.sifa.defs#stageSeriesA",
+        "id.sifa.defs#stageSeriesB",
+        "id.sifa.defs#stageSeriesCPlus",
+        "id.sifa.defs#stageGrowth",
+        "id.sifa.defs#stageSecondary",
+        "id.sifa.defs#stageOther"
+      ]
+    },
+    "stagePreSeed": { "type": "token", "description": "Pre-seed round." },
+    "stageSeed": { "type": "token", "description": "Seed round." },
+    "stageSeriesA": { "type": "token", "description": "Series A round." },
+    "stageSeriesB": { "type": "token", "description": "Series B round." },
+    "stageSeriesCPlus": { "type": "token", "description": "Series C or later round." },
+    "stageGrowth": { "type": "token", "description": "Growth or late-stage round." },
+    "stageSecondary": {
+      "type": "token",
+      "description": "Purchase of existing shares from another holder rather than newly issued shares."
+    },
+    "stageOther": {
+      "type": "token",
+      "description": "A stage that fits none of the above, including rounds that predate the standard naming."
+    },
+
+    "investmentStatus": {
+      "type": "string",
+      "description": "Where the position stands now. Recording a write-off is showing your work; Sifa never derives a hit rate or return from these values.",
+      "knownValues": [
+        "id.sifa.defs#investmentActive",
+        "id.sifa.defs#investmentExited",
+        "id.sifa.defs#investmentWrittenOff",
+        "id.sifa.defs#investmentUndisclosed"
+      ]
+    },
+    "investmentActive": {
+      "type": "token",
+      "description": "The position is still held."
+    },
+    "investmentExited": {
+      "type": "token",
+      "description": "The position was realised through an acquisition, IPO, or secondary sale."
+    },
+    "investmentWrittenOff": {
+      "type": "token",
+      "description": "The company failed or the position was written down to nothing."
+    },
+    "investmentUndisclosed": {
+      "type": "token",
+      "description": "The person prefers not to say where the position stands."
+    },
+
+    "investmentAmount": {
+      "type": "object",
+      "description": "An optional, deliberately structured amount. Free text was rejected here because an unparseable money string is worse than no amount at all.",
+      "required": ["value", "currency"],
+      "properties": {
+        "value": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Amount in whole major currency units (euros, not cents). Cheque sizes are round numbers, and whole units avoid the ambiguity of a bare figure."
+        },
+        "currency": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 3,
+          "description": "ISO 4217 three-letter currency code, uppercase. Enforced at the app layer."
+        }
+      }
+    },
+
     "artifactLink": {
       "type": "object",
       "description": "A public artifact proving a piece of work. Reusable across involvement, and later projects/publications.",

--- a/lexicons/id/sifa/profile/investment.json
+++ b/lexicons/id/sifa/profile/investment.json
@@ -1,0 +1,101 @@
+{
+  "lexicon": 1,
+  "id": "id.sifa.profile.investment",
+  "description": "Capital the user put into a company or fund — an angel cheque, a syndicate position, a limited-partner commitment. Distinct from roles with duties (position, which now covers board seats and advisory work) and from equity received as compensation, which belongs to the position that granted it.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record representing one capital position.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["company", "createdAt"],
+        "properties": {
+          "company": {
+            "type": "string",
+            "minLength": 1,
+            "maxGraphemes": 256,
+            "maxLength": 2560,
+            "description": "Name of the company invested in. For a limited-partner entry this is the fund itself, since an LP commits to the fund rather than to its portfolio."
+          },
+          "companyDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the company's ATproto account, if one exists."
+          },
+          "entityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the company the user selected from a resolver dropdown: a Wikidata Q-ID URI, a ROR URI, or an LEI URI. Absent for free-text entries."
+          },
+          "role": {
+            "type": "ref",
+            "ref": "id.sifa.defs#investmentRole",
+            "description": "How the capital went in."
+          },
+          "stage": {
+            "type": "ref",
+            "ref": "id.sifa.defs#investmentStage",
+            "description": "The company's funding stage at the time of the investment."
+          },
+          "status": {
+            "type": "ref",
+            "ref": "id.sifa.defs#investmentStatus",
+            "description": "Where the position stands now, including written off."
+          },
+          "via": {
+            "type": "string",
+            "maxGraphemes": 256,
+            "maxLength": 2560,
+            "description": "Name of the investment vehicle the capital went through, if any. Omit for a cheque written in the person's own name."
+          },
+          "viaDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the vehicle's ATproto account, if one exists."
+          },
+          "viaEntityRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Portable, app-neutral identifier for the vehicle selected from a resolver dropdown: a Wikidata Q-ID URI, a ROR URI, or an LEI URI. Funds carry LEIs by regulation, so this resolves more often than it does for ordinary companies. Absent for per-deal SPVs and unregistered vehicles."
+          },
+          "amount": {
+            "type": "ref",
+            "ref": "id.sifa.defs#investmentAmount",
+            "description": "How much was invested. Optional and empty by default — cheque size is a personal financial disclosure, and clients must not prompt for it."
+          },
+          "startedAt": {
+            "type": "string",
+            "description": "Date of the investment in YYYY-MM or YYYY-MM-DD format. Freeform (NOT strict datetime) to allow partial dates."
+          },
+          "endedAt": {
+            "type": "string",
+            "description": "Date the position ended, on exit or write-off, in YYYY-MM or YYYY-MM-DD format. Omit while the position is held."
+          },
+          "description": {
+            "type": "string",
+            "maxGraphemes": 5000,
+            "maxLength": 50000,
+            "description": "What the company does and what the person contributes beyond capital."
+          },
+          "links": {
+            "type": "array",
+            "maxLength": 50,
+            "description": "Public artifacts relating to the investment (round announcement, portfolio page, filing).",
+            "items": { "type": "ref", "ref": "id.sifa.defs#artifactLink" }
+          },
+          "labels": {
+            "type": "union",
+            "description": "Self-label values for this record.",
+            "refs": ["com.atproto.label.defs#selfLabels"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -105,6 +105,7 @@ const USER_TEXT_FIELDS = new Set([
   'company',
   'companyName',
   'onBehalfOf',
+  'via',
   'title',
   'subtitle',
   'subCategory',
@@ -215,6 +216,8 @@ const DATE_ONLY_FIELDS = new Set([
   'id.sifa.profile.project.endedAt',
   'id.sifa.profile.involvement.startedAt',
   'id.sifa.profile.involvement.endedAt',
+  'id.sifa.profile.investment.startedAt',
+  'id.sifa.profile.investment.endedAt',
   'id.sifa.profile.volunteering.startedAt',
   'id.sifa.profile.volunteering.endedAt',
   'id.sifa.profile.certification.issuedAt',
@@ -1314,5 +1317,152 @@ describe('Position onBehalfOf field', () => {
 
   it('position required fields are unchanged (backward compatible)', () => {
     expect(required).toEqual(['title', 'startedAt', 'createdAt']);
+  });
+});
+
+describe('id.sifa.profile.investment', () => {
+  const investment = recordLexicons.find((l) => l.doc.id === 'id.sifa.profile.investment');
+  const properties = investment?.doc.defs.main.record?.properties;
+  const required = investment?.doc.defs.main.record?.required ?? [];
+
+  it('exists as a tid-keyed record', () => {
+    expect(investment).toBeDefined();
+    expect(investment?.doc.defs.main.key).toBe('tid');
+  });
+
+  // Money-in only. Board seats and advisory roles are career-shaped and live on
+  // position; granted equity is compensation, not capital at risk. See #86.
+  it('description states that this record is capital deployed, not a role', () => {
+    expect(investment?.doc.description).toMatch(/capital/i);
+  });
+
+  // An investment renders as a list rather than a timeline, so a missing month does not
+  // break the display the way it would on a career entry. Only the company is essential.
+  it('requires only company and createdAt', () => {
+    expect(required).toEqual(['company', 'createdAt']);
+  });
+
+  it('company is a non-empty capped string', () => {
+    expect(properties?.company?.type).toBe('string');
+    expect(properties?.company?.minLength).toBe(1);
+    expect(properties?.company?.maxGraphemes).toBe(256);
+  });
+
+  it('carries the company resolver pair alongside the free-text name', () => {
+    expect(properties?.companyDid?.format).toBe('did');
+    expect(properties?.entityRef?.format).toBe('uri');
+    expect(required).not.toContain('companyDid');
+    expect(required).not.toContain('entityRef');
+  });
+
+  // The vehicle gets the same triple as the company: an investor almost always also
+  // holds a position at their own vehicle, and free text alone would put two unlinked
+  // representations of one org on a single profile.
+  it('carries the full via / viaDid / viaEntityRef triple', () => {
+    expect(properties?.via?.type).toBe('string');
+    expect(properties?.via?.maxGraphemes).toBe(256);
+    expect(properties?.viaDid?.format).toBe('did');
+    expect(properties?.viaEntityRef?.format).toBe('uri');
+    for (const field of ['via', 'viaDid', 'viaEntityRef']) {
+      expect(required).not.toContain(field);
+    }
+  });
+
+  it('role and stage and status reference the shared defs', () => {
+    expect(properties?.role?.ref).toBe('id.sifa.defs#investmentRole');
+    expect(properties?.stage?.ref).toBe('id.sifa.defs#investmentStage');
+    expect(properties?.status?.ref).toBe('id.sifa.defs#investmentStatus');
+  });
+
+  it('amount is an optional structured value, never a free string', () => {
+    expect(properties?.amount?.type).toBe('ref');
+    expect(properties?.amount?.ref).toBe('id.sifa.defs#investmentAmount');
+    expect(required).not.toContain('amount');
+  });
+
+  it('links reuse the shared artifactLink shape', () => {
+    expect(properties?.links?.type).toBe('array');
+    expect(properties?.links?.items?.ref).toBe('id.sifa.defs#artifactLink');
+    expect(properties?.links?.maxLength).toBe(50);
+  });
+
+  // Deploying capital does not demonstrate a skill. The advisory half of an
+  // investor's relationship with a company is a position, which already carries skills.
+  it('has no skills field', () => {
+    expect(properties?.skills).toBeUndefined();
+  });
+
+  it('supports self-labels like the sibling profile records', () => {
+    expect(properties?.labels?.type).toBe('union');
+    expect(properties?.labels?.refs).toContain('com.atproto.label.defs#selfLabels');
+  });
+});
+
+describe('id.sifa.defs investment additions', () => {
+  interface DefsDoc {
+    defs: Record<
+      string,
+      {
+        type: string;
+        description?: string;
+        knownValues?: string[];
+        required?: string[];
+        properties?: Record<
+          string,
+          { type: string; format?: string; knownValues?: string[]; maxLength?: number }
+        >;
+      }
+    >;
+  }
+  const defs = JSON.parse(readFileSync(join(LEXICONS_DIR, 'defs.json'), 'utf-8')) as DefsDoc;
+
+  // GP is deliberately absent: running a fund is a job (already a position), and
+  // offering it here would let a partner claim the fund's whole portfolio as personal
+  // cheques. A partner's own GP commit is an LP record against their own fund.
+  it('investmentRole covers angel, syndicate member and LP, but not GP', () => {
+    expect(defs.defs.investmentRole?.type).toBe('string');
+    expect(defs.defs.investmentRole?.knownValues).toEqual([
+      'id.sifa.defs#angelInvestment',
+      'id.sifa.defs#syndicateInvestment',
+      'id.sifa.defs#limitedPartner',
+      'id.sifa.defs#otherInvestment',
+    ]);
+    expect(defs.defs.investmentRole?.knownValues).not.toContain('id.sifa.defs#generalPartner');
+  });
+
+  it('investmentStatus can record a write-off', () => {
+    expect(defs.defs.investmentStatus?.knownValues).toEqual([
+      'id.sifa.defs#investmentActive',
+      'id.sifa.defs#investmentExited',
+      'id.sifa.defs#investmentWrittenOff',
+      'id.sifa.defs#investmentUndisclosed',
+    ]);
+  });
+
+  it('investmentStage records the stage at time of investment', () => {
+    expect(defs.defs.investmentStage?.type).toBe('string');
+    expect(defs.defs.investmentStage?.description).toMatch(/at.*time|when.*invest/i);
+    expect(defs.defs.investmentStage?.knownValues?.length).toBeGreaterThan(3);
+  });
+
+  it.each([
+    'angelInvestment',
+    'syndicateInvestment',
+    'limitedPartner',
+    'otherInvestment',
+    'investmentActive',
+    'investmentExited',
+    'investmentWrittenOff',
+    'investmentUndisclosed',
+  ])('declares the %s token', (token) => {
+    expect(defs.defs[token]?.type).toBe('token');
+    expect(defs.defs[token]?.description?.length).toBeGreaterThan(0);
+  });
+
+  it('investmentAmount requires both a value and an ISO 4217 currency', () => {
+    expect(defs.defs.investmentAmount?.type).toBe('object');
+    expect([...(defs.defs.investmentAmount?.required ?? [])].sort()).toEqual(['currency', 'value']);
+    expect(defs.defs.investmentAmount?.properties?.value?.type).toBe('integer');
+    expect(defs.defs.investmentAmount?.properties?.currency?.maxLength).toBe(3);
   });
 });


### PR DESCRIPTION
Closes #87. Pairs with #88 (board/advisory `employmentType`), which is independent and can land in either order.

LinkedIn has no slot for investments, so people file each portfolio company as a job. The observed profile carried eight `Investor at X` Experience entries with no employment behind any of them, each pushing the real operating history further down. The workaround damages the section it hides in.

## Added

`lexicons/id/sifa/profile/investment.json` — tid-keyed record. Required: `company`, `createdAt` only.

`defs.json` gains `investmentRole`, `investmentStage`, `investmentStatus`, `investmentAmount` and their tokens.

## Scope calls

**Money-in only.** Board seats and advisory roles are career-shaped and live on `position` (#88). Granted equity — advisor grants, options, founder shares — is compensation rather than capital at risk, so it belongs to the position that granted it.

**No GP role.** Running a fund is a job and is already a `position`. Offering `GP` would let a partner list the fund's entire portfolio as personal cheques. A partner's own commit is a `limitedPartner` entry against their own fund. Attributing a fund's deals to individual partners requires the fund to assert who led — company-side work, parked.

**`status` includes `investmentWrittenOff`.** Publishing failures is showing your work, which a portfolio brag page cannot do. Sifa never derives a hit rate or return from it, asserted in the def description.

**Vehicle gets the full resolver triple**, not free text with an optional upgrade. An investor almost always also holds a `position` at their own vehicle; free text alone would put two unlinked representations of one organization on a single profile. Funds carry LEIs by regulation, so this resolves more often than it does for ordinary companies.

## Three deviations from the decision doc, made during implementation

1. **No `skills` field.** The doc listed one. Deploying capital does not demonstrate a skill, and the advisory half of an investor's relationship with a company is a `position`, which already carries skills.
2. **`required` is `[company, createdAt]`, not including `startedAt`.** `position` requires `startedAt` because a job without dates breaks a timeline. Investments render as a list where `status` matters more than duration, and an angel may genuinely not recall the month of a 2011 cheque.
3. **`amount` is structured**, not a string: whole major currency units plus an ISO 4217 code. An unparseable money string is worse than no amount and cannot be fixed later.

The decision doc has been updated to match.

## Notes

- `amount` is empty by default and clients must not prompt for it — cheque size is a personal financial disclosure. Stated in the field description so it survives past this PR.
- For a `limitedPartner` entry the named entity is the fund, not a portfolio company, since an LP commits to the fund. Documented on the `company` field.
- Never prefilled from third-party data, and not reachable from the LinkedIn importer, which is a 1:1 passthrough by design.
- `via` added to the suite's `USER_TEXT_FIELDS`; `startedAt`/`endedAt` added to `DATE_ONLY_FIELDS`.

## Tests

22 new assertions, written before the schema (red → green). 424 passing. `generate` (30 sifa types, up from 29), `typecheck`, `lint`, `format` all clean.

Decision doc: `decisions/2026-08-06-investment-records.md` in the Sifa workspace.
