### PR TITLE
feat(view): expose onBehalfOf on positionView

### DIFF
--- a/lexicons/id/sifa/getProfileView.json
+++ b/lexicons/id/sifa/getProfileView.json
@@ -413,6 +413,24 @@
           "ref": "id.sifa.defs#employmentType",
           "description": "Employment arrangement."
         },
+        "onBehalfOf": {
+          "type": "string",
+          "description": "Party this role is held on behalf of, when the person represents someone else — most often a fund whose board seat this is. A disclosure, not a role type. Absent for independent roles."
+        },
+        "onBehalfOfDid": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the represented party, when known. May be an organization or a person."
+        },
+        "onBehalfOfEntityRef": {
+          "type": "string",
+          "format": "uri",
+          "description": "Pointer URI to the resolved entity for the represented party."
+        },
+        "onBehalfOfEntityName": {
+          "type": "string",
+          "description": "Resolved canonical name for the represented party. Present only when the reference resolves; clients render onBehalfOf otherwise, never the raw URI."
+        },
         "workplaceType": {
           "type": "ref",
           "ref": "id.sifa.defs#workplaceType",

--- a/tests/lexicons.test.ts
+++ b/tests/lexicons.test.ts
@@ -1466,3 +1466,33 @@ describe('id.sifa.defs investment additions', () => {
     expect(defs.defs.investmentAmount?.properties?.currency?.maxLength).toBe(3);
   });
 });
+
+describe('getProfileView positionView onBehalfOf', () => {
+  interface ViewDoc {
+    defs: Record<
+      string,
+      { properties?: Record<string, { type: string; format?: string; description?: string }> }
+    >;
+  }
+  const view = JSON.parse(
+    readFileSync(join(LEXICONS_DIR, 'getProfileView.json'), 'utf-8'),
+  ) as ViewDoc;
+  const props = view.defs.positionView?.properties;
+
+  it('exposes the represented party alongside the role', () => {
+    expect(props?.onBehalfOf?.type).toBe('string');
+    expect(props?.onBehalfOfDid?.format).toBe('did');
+    expect(props?.onBehalfOfEntityRef?.format).toBe('uri');
+  });
+
+  // The view resolves entityRef into a canonical entityName, so the represented party
+  // needs the same resolved-name field or clients would render a bare URI.
+  it('resolves the represented party to a display name, mirroring entityName', () => {
+    expect(props?.onBehalfOfEntityName?.type).toBe('string');
+    expect(props?.entityName).toBeDefined();
+  });
+
+  it('describes onBehalfOf as a representation disclosure', () => {
+    expect(props?.onBehalfOf?.description).toMatch(/behalf|represent/i);
+  });
+});


### PR DESCRIPTION
Follow-up to #88, which added `onBehalfOf` / `onBehalfOfDid` / `onBehalfOfEntityRef` to the position **record** but left the profile **view** unchanged — so a board seat held as a fund's representative currently reads identically to an independent one on the wire.

## Change

Four fields on `getProfileView.positionView`, placed next to `employmentType` since the disclosure modifies the role:

- `onBehalfOf`, `onBehalfOfDid`, `onBehalfOfEntityRef` — mirroring the record
- `onBehalfOfEntityName` — view-only, resolved

## Why the fourth field

`positionView` already pairs `entityRef` with a resolved `entityName`, because a client cannot render a Wikidata Q-ID or an LEI to a human. The represented party needs the same pairing or clients face a choice between printing a raw URI and dropping the disclosure — and a disclosure that gets dropped for rendering reasons is worse than not having the field.

Its description states the fallback explicitly: render `onBehalfOf` when the reference does not resolve, never the raw URI.

## Tests

3 new assertions, written first (red → green). 440 passing. `generate`, `typecheck`, `lint`, `format` clean.

Part of chain B in `decisions/2026-08-06-investment-records.md`: lexicon → SDK → API (migration, firehose, write, view) → web form.
