### PR TITLE
feat(lexicons): annotate terms with their RDF equivalents

### DIFF
--- a/lexicons/id/sifa/org/profile.json
+++ b/lexicons/id/sifa/org/profile.json
@@ -64,7 +64,8 @@
             "description": "Client-declared timestamp when this organization profile was originally created."
           }
         }
-      }
+      },
+      "x-skos:exactMatch": ["schema:Organization", "org:FormalOrganization"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/certification.json
+++ b/lexicons/id/sifa/profile/certification.json
@@ -43,7 +43,8 @@
           "credentialUrl": {
             "type": "string",
             "format": "uri",
-            "description": "URL to verify the credential."
+            "description": "URL to verify the credential.",
+            "x-skos:exactMatch": ["schema:url"]
           },
           "issuedAt": {
             "type": "string",
@@ -51,7 +52,8 @@
           },
           "expiresAt": {
             "type": "string",
-            "description": "Expiry date in YYYY-MM or YYYY-MM-DD format. Omit if the certification does not expire."
+            "description": "Expiry date in YYYY-MM or YYYY-MM-DD format. Omit if the certification does not expire.",
+            "x-skos:exactMatch": ["schema:validUntil"]
           },
           "labels": {
             "type": "union",
@@ -64,7 +66,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:exactMatch": ["schema:EducationalOccupationalCredential"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/course.json
+++ b/lexicons/id/sifa/profile/course.json
@@ -22,7 +22,8 @@
             "type": "string",
             "maxGraphemes": 50,
             "maxLength": 500,
-            "description": "Course number or code (e.g., 'CS101')."
+            "description": "Course number or code (e.g., 'CS101').",
+            "x-skos:exactMatch": ["schema:courseCode"]
           },
           "institution": {
             "type": "string",
@@ -55,7 +56,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:exactMatch": ["schema:Course"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/education.json
+++ b/lexicons/id/sifa/profile/education.json
@@ -16,7 +16,8 @@
             "minLength": 1,
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Name of the educational institution."
+            "description": "Name of the educational institution.",
+            "x-skos:exactMatch": ["schema:alumniOf"]
           },
           "institutionDid": {
             "type": "string",
@@ -32,13 +33,15 @@
             "type": "string",
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Degree name (e.g., 'Bachelor of Science', 'Master of Arts')."
+            "description": "Degree name (e.g., 'Bachelor of Science', 'Master of Arts').",
+            "x-skos:closeMatch": ["schema:hasCredential", "bibo:degree"]
           },
           "fieldOfStudy": {
             "type": "string",
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Field of study or major."
+            "description": "Field of study or major.",
+            "x-skos:closeMatch": ["schema:educationalCredentialAwarded"]
           },
           "grade": {
             "type": "string",
@@ -82,7 +85,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:closeMatch": ["schema:EducationalOccupationalCredential"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/externalAccount.json
+++ b/lexicons/id/sifa/profile/externalAccount.json
@@ -57,7 +57,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:exactMatch": ["schema:sameAs", "foaf:account"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/honor.json
+++ b/lexicons/id/sifa/profile/honor.json
@@ -50,7 +50,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:broadMatch": ["schema:award"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/involvement.json
+++ b/lexicons/id/sifa/profile/involvement.json
@@ -1,11 +1,11 @@
 {
   "lexicon": 1,
   "id": "id.sifa.profile.involvement",
-  "description": "Uncompensated involvement with an external project, community, event, or cause the user does not own or run — open-source, community, charity, or civic work. Distinct from paid roles (position), things you own (project), and paid employment.",
+  "description": "Uncompensated involvement with an external project, community, event, or cause the user does not own or run \u2014 open-source, community, charity, or civic work. Distinct from paid roles (position), things you own (project), and paid employment.",
   "defs": {
     "main": {
       "type": "record",
-      "description": "Record representing one involvement — an ongoing role and/or a body of discrete contributions to a single upstream.",
+      "description": "Record representing one involvement \u2014 an ongoing role and/or a body of discrete contributions to a single upstream.",
       "key": "tid",
       "record": {
         "type": "object",
@@ -26,7 +26,7 @@
             "type": "string",
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Name of the project, community, event, or cause (e.g. 'atproto', 'Linux kernel', 'PyCon NL'). Optional — a one-off contribution need not name an organization."
+            "description": "Name of the project, community, event, or cause (e.g. 'atproto', 'Linux kernel', 'PyCon NL'). Optional \u2014 a one-off contribution need not name an organization."
           },
           "upstreamDid": {
             "type": "string",
@@ -111,7 +111,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:broadMatch": ["org:Membership"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/language.json
+++ b/lexicons/id/sifa/profile/language.json
@@ -35,7 +35,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:exactMatch": ["schema:knowsLanguage"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -16,7 +16,8 @@
             "minLength": 1,
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Company or organization name. Optional: omit for self-employed, freelance, contract, or independent work that has no separately named or registered entity."
+            "description": "Company or organization name. Optional: omit for self-employed, freelance, contract, or independent work that has no separately named or registered entity.",
+            "x-skos:exactMatch": ["org:organization", "schema:worksFor"]
           },
           "companyDid": {
             "type": "string",
@@ -26,20 +27,23 @@
           "entityRef": {
             "type": "string",
             "format": "uri",
-            "description": "Portable, app-neutral identifier for the organization the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the org claims an ATproto account. Absent for free-text or independent/self-employed positions."
+            "description": "Portable, app-neutral identifier for the organization the user selected from a resolver dropdown: a Wikidata Q-ID URI (http://www.wikidata.org/entity/Q...), a ROR URI, or an LEI URI. Enables deterministic resolution to a canonical entity even before the org claims an ATproto account. Absent for free-text or independent/self-employed positions.",
+            "x-skos:closeMatch": ["schema:sameAs"]
           },
           "title": {
             "type": "string",
             "minLength": 1,
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Job title or role name."
+            "description": "Job title or role name.",
+            "x-skos:exactMatch": ["org:role", "schema:roleName"]
           },
           "description": {
             "type": "string",
             "maxGraphemes": 5000,
             "maxLength": 50000,
-            "description": "Description of responsibilities, achievements, and duties."
+            "description": "Description of responsibilities, achievements, and duties.",
+            "x-skos:exactMatch": ["dcterms:description"]
           },
           "employmentType": {
             "type": "string",
@@ -61,13 +65,14 @@
               "id.sifa.defs#boardMember",
               "id.sifa.defs#boardObserver",
               "id.sifa.defs#advisor"
-            ]
+            ],
+            "x-skos:closeMatch": ["schema:employmentType"]
           },
           "onBehalfOf": {
             "type": "string",
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Name of the party this role is held on behalf of, when the person represents someone else — most often a fund whose board seat this is. A disclosure, not a role type. Omit for independent seats."
+            "description": "Name of the party this role is held on behalf of, when the person represents someone else \u2014 most often a fund whose board seat this is. A disclosure, not a role type. Omit for independent seats."
           },
           "onBehalfOfDid": {
             "type": "string",
@@ -82,20 +87,24 @@
           "workplaceType": {
             "type": "string",
             "description": "Workplace arrangement (on-site, remote, hybrid).",
-            "knownValues": ["id.sifa.defs#onSite", "id.sifa.defs#remote", "id.sifa.defs#hybrid"]
+            "knownValues": ["id.sifa.defs#onSite", "id.sifa.defs#remote", "id.sifa.defs#hybrid"],
+            "x-skos:narrowMatch": ["schema:jobLocationType"]
           },
           "location": {
             "type": "ref",
             "ref": "community.lexicon.location.address",
-            "description": "Work location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
+            "description": "Work location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer.",
+            "x-skos:exactMatch": ["schema:jobLocation"]
           },
           "startedAt": {
             "type": "string",
-            "description": "Start date of the position in YYYY-MM or YYYY-MM-DD format."
+            "description": "Start date of the position in YYYY-MM or YYYY-MM-DD format.",
+            "x-skos:exactMatch": ["schema:startDate"]
           },
           "endedAt": {
             "type": "string",
-            "description": "End date of the position in YYYY-MM or YYYY-MM-DD format. Omit if this is a current position."
+            "description": "End date of the position in YYYY-MM or YYYY-MM-DD format. Omit if this is a current position.",
+            "x-skos:exactMatch": ["schema:endDate"]
           },
           "skills": {
             "type": "array",
@@ -121,7 +130,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:closeMatch": ["org:Membership", "schema:OrganizationRole"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/presentation.json
+++ b/lexicons/id/sifa/profile/presentation.json
@@ -16,18 +16,21 @@
             "minLength": 1,
             "maxGraphemes": 300,
             "maxLength": 3000,
-            "description": "Title of the presentation."
+            "description": "Title of the presentation.",
+            "x-skos:exactMatch": ["dcterms:title", "schema:name"]
           },
           "description": {
             "type": "string",
             "maxGraphemes": 5000,
             "maxLength": 50000,
-            "description": "Description or abstract of the presentation."
+            "description": "Description or abstract of the presentation.",
+            "x-skos:exactMatch": ["bibo:abstract", "schema:abstract"]
           },
           "duration": {
             "type": "ref",
             "ref": "#duration",
-            "description": "Typical length of the presentation, a fixed value or a range, in minutes."
+            "description": "Typical length of the presentation, a fixed value or a range, in minutes.",
+            "x-skos:narrowMatch": ["schema:timeRequired"]
           },
           "intendedAudiences": {
             "type": "array",
@@ -37,7 +40,8 @@
               "maxGraphemes": 100,
               "maxLength": 1000
             },
-            "description": "Intended audiences for this presentation, open text (e.g. 'Engineering leaders', 'Beginners')."
+            "description": "Intended audiences for this presentation, open text (e.g. 'Engineering leaders', 'Beginners').",
+            "x-skos:closeMatch": ["schema:audience"]
           },
           "links": {
             "type": "array",
@@ -51,13 +55,15 @@
           "writeupRef": {
             "type": "ref",
             "ref": "id.sifa.defs#externalRecordRef",
-            "description": "Optional reference to a long-form write-up of this presentation (a pub.leaflet.document or site.standard.document holding video, transcript, or article)."
+            "description": "Optional reference to a long-form write-up of this presentation (a pub.leaflet.document or site.standard.document holding video, transcript, or article).",
+            "x-skos:closeMatch": ["dcterms:isReferencedBy", "schema:subjectOf"]
           },
           "coverImage": {
             "type": "blob",
             "accept": ["image/png", "image/jpeg", "image/webp"],
             "maxSize": 2000000,
-            "description": "Optional cover image for the presentation. Rendered as the talk-page hero and OpenGraph image. Max 2 MB, PNG, JPEG, or WebP."
+            "description": "Optional cover image for the presentation. Rendered as the talk-page hero and OpenGraph image. Max 2 MB, PNG, JPEG, or WebP.",
+            "x-skos:exactMatch": ["schema:image", "foaf:depiction"]
           },
           "createdAt": {
             "type": "string",
@@ -65,7 +71,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:closeMatch": ["bibo:Slideshow", "schema:PresentationDigitalDocument"]
     },
     "duration": {
       "type": "object",

--- a/lexicons/id/sifa/profile/presentationDelivery.json
+++ b/lexicons/id/sifa/profile/presentationDelivery.json
@@ -14,7 +14,8 @@
           "presentationRef": {
             "type": "ref",
             "ref": "id.sifa.defs#externalRecordRef",
-            "description": "Optional reference to the id.sifa.profile.presentation (the content) delivered here. When set, title, duration, and audiences are taken from it."
+            "description": "Optional reference to the id.sifa.profile.presentation (the content) delivered here. When set, title, duration, and audiences are taken from it.",
+            "x-skos:closeMatch": ["bibo:presentedAt", "schema:workPerformed"]
           },
           "sameAs": {
             "type": "ref",
@@ -25,7 +26,8 @@
             "type": "string",
             "maxGraphemes": 300,
             "maxLength": 3000,
-            "description": "Fallback title for this delivery, used when no presentationRef is set."
+            "description": "Fallback title for this delivery, used when no presentationRef is set.",
+            "x-skos:exactMatch": ["dcterms:title", "schema:name"]
           },
           "role": {
             "type": "string",
@@ -38,18 +40,21 @@
               "id.sifa.defs#keynote",
               "id.sifa.defs#workshop",
               "id.sifa.defs#host"
-            ]
+            ],
+            "x-skos:closeMatch": ["bibo:performer", "schema:performer"]
           },
           "eventName": {
             "type": "string",
             "maxGraphemes": 300,
             "maxLength": 3000,
-            "description": "Name of the event or venue. On the linked branch, hydrated from the calendar event's name."
+            "description": "Name of the event or venue. On the linked branch, hydrated from the calendar event's name.",
+            "x-skos:closeMatch": ["schema:superEvent", "bibo:Conference"]
           },
           "date": {
             "type": "string",
             "maxLength": 10,
-            "description": "Calendar date of this delivery as YYYY-MM-DD (day only, no time). Future dates are allowed for upcoming deliveries. The day-only shape is enforced at the app layer. On the linked branch, derived from the event's startsAt in the event's own offset."
+            "description": "Calendar date of this delivery as YYYY-MM-DD (day only, no time). Future dates are allowed for upcoming deliveries. The day-only shape is enforced at the app layer. On the linked branch, derived from the event's startsAt in the event's own offset.",
+            "x-skos:exactMatch": ["schema:startDate", "event:time"]
           },
           "location": {
             "type": "string",
@@ -60,7 +65,8 @@
           "address": {
             "type": "ref",
             "ref": "community.lexicon.location.address",
-            "description": "Structured delivery location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer and surfaces country (for a flag) and locality (city); region, postalCode, and street are unused for deliveries. Takes precedence over the legacy location string when present."
+            "description": "Structured delivery location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer and surfaces country (for a flag) and locality (city); region, postalCode, and street are unused for deliveries. Takes precedence over the legacy location string when present.",
+            "x-skos:exactMatch": ["schema:location", "event:place"]
           },
           "mode": {
             "type": "string",
@@ -69,7 +75,8 @@
               "community.lexicon.calendar.event#inperson",
               "community.lexicon.calendar.event#virtual",
               "community.lexicon.calendar.event#hybrid"
-            ]
+            ],
+            "x-skos:exactMatch": ["schema:eventAttendanceMode"]
           },
           "status": {
             "type": "string",
@@ -80,7 +87,8 @@
               "community.lexicon.calendar.event#postponed",
               "community.lexicon.calendar.event#rescheduled",
               "community.lexicon.calendar.event#planned"
-            ]
+            ],
+            "x-skos:exactMatch": ["schema:eventStatus"]
           },
           "links": {
             "type": "array",
@@ -103,7 +111,8 @@
               "type": "string",
               "format": "did"
             },
-            "description": "DIDs of co-speakers who presented alongside the author at this occasion. Any atproto account is allowed; hydrated to profile cards on read and linked to the co-speaker's Sifa profile."
+            "description": "DIDs of co-speakers who presented alongside the author at this occasion. Any atproto account is allowed; hydrated to profile cards on read and linked to the co-speaker's Sifa profile.",
+            "x-skos:exactMatch": ["schema:performer"]
           },
           "createdAt": {
             "type": "string",
@@ -111,7 +120,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:closeMatch": ["schema:Event", "event:Event"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/project.json
+++ b/lexicons/id/sifa/profile/project.json
@@ -72,7 +72,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:exactMatch": ["schema:Project", "foaf:Project"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/publication.json
+++ b/lexicons/id/sifa/profile/publication.json
@@ -16,30 +16,35 @@
             "minLength": 1,
             "maxGraphemes": 200,
             "maxLength": 2000,
-            "description": "Publication title."
+            "description": "Publication title.",
+            "x-skos:exactMatch": ["dcterms:title", "schema:name"]
           },
           "subtitle": {
             "type": "string",
             "maxGraphemes": 200,
             "maxLength": 2000,
-            "description": "Publication subtitle. Carries the distinguishing part of a title that sources such as Crossref and ORCID store separately from the main title -- for example the volume/part designation and descriptive clause of a multi-part paper series (\"III. Using cluster masses to create a cleaned catalogue\"). Absent for publications with no subtitle."
+            "description": "Publication subtitle. Carries the distinguishing part of a title that sources such as Crossref and ORCID store separately from the main title -- for example the volume/part designation and descriptive clause of a multi-part paper series (\"III. Using cluster masses to create a cleaned catalogue\"). Absent for publications with no subtitle.",
+            "x-skos:closeMatch": ["schema:alternativeHeadline"]
           },
           "publisher": {
             "type": "string",
             "maxGraphemes": 256,
             "maxLength": 2560,
-            "description": "Publisher, journal, or venue name."
+            "description": "Publisher, journal, or venue name.",
+            "x-skos:exactMatch": ["dcterms:publisher", "schema:publisher"]
           },
           "url": {
             "type": "string",
             "format": "uri",
-            "description": "URL to the publication."
+            "description": "URL to the publication.",
+            "x-skos:exactMatch": ["bibo:uri", "schema:url"]
           },
           "description": {
             "type": "string",
             "maxGraphemes": 5000,
             "maxLength": 50000,
-            "description": "Description or abstract."
+            "description": "Description or abstract.",
+            "x-skos:exactMatch": ["bibo:abstract", "schema:abstract"]
           },
           "sameAs": {
             "type": "ref",
@@ -53,11 +58,13 @@
               "type": "ref",
               "ref": "#author"
             },
-            "description": "Co-authors. The record owner is always an implicit author."
+            "description": "Co-authors. The record owner is always an implicit author.",
+            "x-skos:exactMatch": ["bibo:authorList", "schema:author"]
           },
           "publishedAt": {
             "type": "string",
-            "description": "Publication date in YYYY-MM or YYYY-MM-DD format."
+            "description": "Publication date in YYYY-MM or YYYY-MM-DD format.",
+            "x-skos:exactMatch": ["dcterms:issued", "schema:datePublished"]
           },
           "createdAt": {
             "type": "string",
@@ -65,7 +72,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:broadMatch": ["bibo:Document", "schema:CreativeWork"]
     },
     "author": {
       "type": "object",

--- a/lexicons/id/sifa/profile/self.json
+++ b/lexicons/id/sifa/profile/self.json
@@ -15,25 +15,29 @@
             "type": "string",
             "maxGraphemes": 64,
             "maxLength": 640,
-            "description": "Professional-context display name. Overrides app.bsky.actor.profile.displayName when present."
+            "description": "Professional-context display name. Overrides app.bsky.actor.profile.displayName when present.",
+            "x-skos:exactMatch": ["schema:name", "foaf:name"]
           },
           "givenName": {
             "type": "string",
             "maxGraphemes": 64,
             "maxLength": 640,
-            "description": "Given (first) name. Maps to Schema.org Person.givenName. Optional; if absent, displayName is used for rendering."
+            "description": "Given (first) name. Maps to Schema.org Person.givenName. Optional; if absent, displayName is used for rendering.",
+            "x-skos:exactMatch": ["schema:givenName", "foaf:givenname"]
           },
           "familyName": {
             "type": "string",
             "maxGraphemes": 64,
             "maxLength": 640,
-            "description": "Family (last) name. Maps to Schema.org Person.familyName. Optional."
+            "description": "Family (last) name. Maps to Schema.org Person.familyName. Optional.",
+            "x-skos:exactMatch": ["schema:familyName", "foaf:family_name"]
           },
           "avatar": {
             "type": "blob",
             "accept": ["image/png", "image/jpeg"],
             "maxSize": 1000000,
-            "description": "Professional-context avatar image. Overrides app.bsky.actor.profile.avatar when present."
+            "description": "Professional-context avatar image. Overrides app.bsky.actor.profile.avatar when present.",
+            "x-skos:exactMatch": ["schema:image", "foaf:depiction"]
           },
           "pronouns": {
             "type": "string",
@@ -45,13 +49,15 @@
             "type": "string",
             "maxGraphemes": 120,
             "maxLength": 1200,
-            "description": "Professional headline (e.g., 'Senior Engineer at Acme Corp'). Distinct from Bluesky's displayName."
+            "description": "Professional headline (e.g., 'Senior Engineer at Acme Corp'). Distinct from Bluesky's displayName.",
+            "x-skos:closeMatch": ["schema:jobTitle"]
           },
           "about": {
             "type": "string",
             "maxGraphemes": 5000,
             "maxLength": 50000,
-            "description": "Professional summary or about section. Longer-form than Bluesky's description field."
+            "description": "Professional summary or about section. Longer-form than Bluesky's description field.",
+            "x-skos:exactMatch": ["schema:description"]
           },
           "industries": {
             "type": "array",
@@ -65,7 +71,8 @@
           "location": {
             "type": "ref",
             "ref": "community.lexicon.location.address",
-            "description": "Professional location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer."
+            "description": "Professional location. Sifa enforces ISO 3166-1 alpha-2 country codes at the app layer.",
+            "x-skos:closeMatch": ["schema:homeLocation"]
           },
           "openTo": {
             "type": "array",
@@ -138,7 +145,8 @@
             "description": "Client-declared timestamp when this profile was originally created."
           }
         }
-      }
+      },
+      "x-skos:exactMatch": ["schema:Person", "foaf:Person"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/skill.json
+++ b/lexicons/id/sifa/profile/skill.json
@@ -42,7 +42,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:closeMatch": ["schema:knowsAbout", "schema:DefinedTerm"]
     }
   }
 }

--- a/lexicons/id/sifa/profile/volunteering.json
+++ b/lexicons/id/sifa/profile/volunteering.json
@@ -60,7 +60,8 @@
             "description": "Client-declared timestamp when this record was originally created."
           }
         }
-      }
+      },
+      "x-skos:closeMatch": ["org:Membership", "schema:OrganizationRole"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "publish:bootstrap": "tsx scripts/oauth-bootstrap.ts",
     "publish:lexicons": "tsx scripts/publish-lexicons.ts",
     "publish:check": "tsx scripts/publish-lexicons.ts --check",
-    "prepare": "husky"
+    "prepare": "husky",
+    "build:term-mappings": "node scripts/build-term-mappings.js"
   },
   "dependencies": {
     "@atproto/lexicon": "0.6.2",

--- a/scripts/build-term-mappings.js
+++ b/scripts/build-term-mappings.js
@@ -1,0 +1,121 @@
+/**
+ * Generate `well-known/term-mappings.json` from the `x-skos:*` annotations in
+ * the lexicon JSON.
+ *
+ * The lexicons are the source of truth: they are what gets published to the
+ * authority PDS, so a third party resolving `id.sifa.*` already has the
+ * annotations in hand. This file is the same information in one flat document
+ * for consumers that would rather fetch one URL than walk 34 schemas.
+ */
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const LEXICONS_DIR = join(ROOT, 'lexicons');
+const OUT = join(ROOT, 'well-known', 'term-mappings.json');
+
+export const VOCABULARIES = {
+  schema: 'https://schema.org/',
+  bibo: 'http://purl.org/ontology/bibo/',
+  dcterms: 'http://purl.org/dc/terms/',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  org: 'http://www.w3.org/ns/org#',
+  prism: 'http://prismstandard.org/namespaces/basic/2.1/',
+  event: 'http://purl.org/NET/c4dm/event.owl#',
+  skos: 'http://www.w3.org/2004/02/skos/core#',
+};
+
+export const MATCH_KEYS = [
+  'x-skos:exactMatch',
+  'x-skos:closeMatch',
+  'x-skos:broadMatch',
+  'x-skos:narrowMatch',
+  'x-skos:relatedMatch',
+];
+
+/**
+ * Records deliberately left unmapped, with the reason. Stated explicitly so a
+ * consumer can tell "we have not got to it" apart from "no external term is
+ * appropriate here". These carry no annotation in the lexicon itself, because
+ * the absence is the point.
+ */
+export const UNMAPPED = [
+  {
+    lexicon: 'id.sifa.confirmation',
+    reason:
+      'A record affirming another record is reification. schema:Review and schema:ClaimReview both imply an evaluation that a confirmation does not make.',
+  },
+  {
+    lexicon: 'id.sifa.endorsement',
+    reason:
+      'Same reification problem as confirmation. Any mapping that lets a consumer aggregate endorsements into a score works against a descriptive-only trust model.',
+  },
+  {
+    lexicon: 'id.sifa.graph.connection',
+    reason:
+      'foaf:knows carries no consent semantics. A Sifa connection is bilateral and confirmed; flattening it would present an unconfirmed acquaintance claim as mutual.',
+  },
+  { lexicon: 'id.sifa.graph.follow', reason: 'See id.sifa.graph.connection.' },
+  { lexicon: 'id.sifa.meeting', reason: 'Attestation semantics; same reification problem.' },
+];
+
+export function findJsonFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...findJsonFiles(full));
+    else if (entry.name.endsWith('.json')) out.push(full);
+  }
+  return out;
+}
+
+function matchOf(node) {
+  for (const key of MATCH_KEYS) {
+    if (Array.isArray(node?.[key])) return { match: key.slice('x-skos:'.length), terms: node[key] };
+  }
+  return null;
+}
+
+export function collectMappings() {
+  const mappings = [];
+  for (const file of findJsonFiles(LEXICONS_DIR).sort()) {
+    const doc = JSON.parse(readFileSync(file, 'utf8'));
+    const nsid =
+      doc.id ??
+      relative(LEXICONS_DIR, file)
+        .replace(/\.json$/, '')
+        .split(sep)
+        .join('.');
+    const main = doc.defs?.main;
+    if (!main) continue;
+
+    const record = matchOf(main);
+    if (record) mappings.push({ lexicon: nsid, ...record });
+
+    const props = main.record?.properties ?? {};
+    for (const field of Object.keys(props).sort()) {
+      const found = matchOf(props[field]);
+      if (found) mappings.push({ lexicon: nsid, field, ...found });
+    }
+  }
+  return mappings;
+}
+
+export function buildDocument() {
+  return {
+    $schema: 'https://sifa.id/schemas/term-mappings/v1.json',
+    version: '1.0.0',
+    description:
+      'Reconciliation between id.sifa.* lexicon terms and existing RDF vocabularies. RDF is used here as vocabulary only: Sifa records are Lexicon JSON on the AT Protocol, and nothing here changes how they are stored or transmitted. Match strengths use SKOS mapping relations.',
+    vocabularies: VOCABULARIES,
+    mappings: collectMappings(),
+    unmapped: UNMAPPED,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const doc = buildDocument();
+  mkdirSync(join(ROOT, 'well-known'), { recursive: true });
+  writeFileSync(OUT, JSON.stringify(doc, null, 2) + '\n');
+  console.log(`Wrote ${doc.mappings.length} mappings + ${doc.unmapped.length} unmapped to ${OUT}`);
+}

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -4,7 +4,7 @@
  * Includes external lexicons (com.atproto.*, community.lexicon.*) that our
  * schemas reference, so lex-cli can resolve all type references.
  */
-import { readdirSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { join, relative, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -63,8 +63,10 @@ function stripAnnotations(node) {
   return node;
 }
 
-const stageDir = join(tmpdir(), `sifa-lexicons-codegen-${process.pid}`);
-rmSync(stageDir, { recursive: true, force: true });
+// mkdtempSync, not a name derived from the pid: a predictable path in the
+// shared temp dir can be pre-created or symlinked by another user
+// (CodeQL js/insecure-temporary-file).
+const stageDir = mkdtempSync(join(tmpdir(), 'sifa-lexicons-codegen-'));
 const stagedFiles = allFiles.map((file) => {
   const staged = join(stageDir, relative(ROOT, file));
   mkdirSync(dirname(staged), { recursive: true });

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -4,8 +4,9 @@
  * Includes external lexicons (com.atproto.*, community.lexicon.*) that our
  * schemas reference, so lex-cli can resolve all type references.
  */
-import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join, relative, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 
 const ROOT = new URL('..', import.meta.url).pathname;
@@ -40,10 +41,45 @@ const allFiles = [...ownFiles, ...externalFiles];
 
 console.log(`Found ${ownFiles.length} own + ${externalFiles.length} external lexicon files`);
 
-execFileSync('npx', ['lex', 'gen-server', OUTPUT_DIR, ...allFiles, '--yes'], {
-  cwd: ROOT,
-  stdio: 'inherit',
+/**
+ * Strip `x-skos:*` term annotations before codegen.
+ *
+ * lex-cli copies unknown keys verbatim into the generated `lexicons.ts` schema
+ * dictionary, which is typed against @atproto/lexicon's closed object types, so
+ * leaving them in fails `tsc`. The annotations belong on the source lexicons,
+ * which is what gets published to the authority PDS and what a lexicon resolver
+ * reads. They are not needed to generate TypeScript types, and stripping them
+ * leaves the generated output byte-identical to a run with no annotations.
+ */
+function stripAnnotations(node) {
+  if (Array.isArray(node)) return node.map(stripAnnotations);
+  if (node && typeof node === 'object') {
+    return Object.fromEntries(
+      Object.entries(node)
+        .filter(([key]) => !key.startsWith('x-skos:'))
+        .map(([key, value]) => [key, stripAnnotations(value)]),
+    );
+  }
+  return node;
+}
+
+const stageDir = join(tmpdir(), `sifa-lexicons-codegen-${process.pid}`);
+rmSync(stageDir, { recursive: true, force: true });
+const stagedFiles = allFiles.map((file) => {
+  const staged = join(stageDir, relative(ROOT, file));
+  mkdirSync(dirname(staged), { recursive: true });
+  writeFileSync(staged, JSON.stringify(stripAnnotations(JSON.parse(readFileSync(file, 'utf8')))));
+  return staged;
 });
+
+try {
+  execFileSync('npx', ['lex', 'gen-server', OUTPUT_DIR, ...stagedFiles, '--yes'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+} finally {
+  rmSync(stageDir, { recursive: true, force: true });
+}
 
 console.log('Running fixup script...');
 execFileSync('node', ['scripts/fixup-generated.js'], { cwd: ROOT, stdio: 'inherit' });

--- a/tests/term-mappings.test.ts
+++ b/tests/term-mappings.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  MATCH_KEYS,
+  UNMAPPED,
+  VOCABULARIES,
+  buildDocument,
+  collectMappings,
+  findJsonFiles,
+} from '../scripts/build-term-mappings.js';
+
+const ROOT = join(import.meta.dirname, '..');
+const LEXICONS_DIR = join(ROOT, 'lexicons');
+
+const docs = findJsonFiles(LEXICONS_DIR).map((f) => ({
+  file: f,
+  doc: JSON.parse(readFileSync(f, 'utf8')),
+}));
+
+const PREFIXES = Object.keys(VOCABULARIES);
+
+function isAnnotationKey(key: string) {
+  return key.startsWith('x-skos:');
+}
+
+describe('term annotations are well formed', () => {
+  it('every x-skos key is a known SKOS mapping relation', () => {
+    for (const { file, doc } of docs) {
+      const walk = (node: unknown, path: string) => {
+        if (!node || typeof node !== 'object') return;
+        for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+          if (isAnnotationKey(key)) {
+            expect(MATCH_KEYS, `${file} ${path}.${key}`).toContain(key);
+            expect(Array.isArray(value), `${file} ${path}.${key} must be an array`).toBe(true);
+            expect((value as unknown[]).length, `${file} ${path}.${key} is empty`).toBeGreaterThan(
+              0,
+            );
+          } else {
+            walk(value, `${path}.${key}`);
+          }
+        }
+      };
+      walk(doc.defs, 'defs');
+    }
+  });
+
+  it('every term uses a declared vocabulary prefix', () => {
+    for (const mapping of collectMappings()) {
+      for (const term of mapping.terms) {
+        const prefix = term.split(':')[0];
+        expect(PREFIXES, `${mapping.lexicon} ${mapping.field ?? '(record)'}: ${term}`).toContain(
+          prefix,
+        );
+        expect(term.split(':')[1]?.length ?? 0).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('no annotation sits at document level', () => {
+    // Document-level keys survive lex-cli codegen but are silently stripped by
+    // `lexiconDoc.parse` in @atproto/lexicon, so an annotation there would be
+    // present in some representations and absent in others with no error.
+    // Def level and property level survive both.
+    for (const { file, doc } of docs) {
+      const stray = Object.keys(doc).filter(isAnnotationKey);
+      expect(stray, `${file} has document-level annotations`).toEqual([]);
+    }
+  });
+});
+
+describe('generated well-known document', () => {
+  const generated = buildDocument();
+  const committed = JSON.parse(
+    readFileSync(join(ROOT, 'well-known', 'term-mappings.json'), 'utf8'),
+  );
+
+  it('is in sync with the lexicons', () => {
+    // Regenerate with `node scripts/build-term-mappings.js` when this fails.
+    expect(committed).toEqual(generated);
+  });
+
+  it('records a mapping for the record types Sifa emits structured data for', () => {
+    const covered = new Set(generated.mappings.map((m) => m.lexicon));
+    for (const nsid of [
+      'id.sifa.profile.self',
+      'id.sifa.profile.position',
+      'id.sifa.profile.education',
+      'id.sifa.profile.publication',
+      'id.sifa.profile.presentation',
+      'id.sifa.profile.presentationDelivery',
+      'id.sifa.profile.certification',
+      'id.sifa.profile.course',
+      'id.sifa.profile.project',
+    ]) {
+      expect(covered, nsid).toContain(nsid);
+    }
+  });
+
+  it('never maps a connection to foaf:knows', () => {
+    const terms = generated.mappings.flatMap((m) => m.terms);
+    expect(terms).not.toContain('foaf:knows');
+  });
+
+  it('states a reason for every deliberately unmapped record', () => {
+    for (const entry of UNMAPPED) {
+      expect(entry.reason.length, entry.lexicon).toBeGreaterThan(0);
+    }
+  });
+
+  it('does not annotate a record it declares unmapped', () => {
+    const mapped = new Set(generated.mappings.map((m) => m.lexicon));
+    for (const entry of UNMAPPED) {
+      expect(mapped, `${entry.lexicon} is both mapped and declared unmapped`).not.toContain(
+        entry.lexicon,
+      );
+    }
+  });
+});

--- a/well-known/term-mappings.json
+++ b/well-known/term-mappings.json
@@ -1,0 +1,383 @@
+{
+  "$schema": "https://sifa.id/schemas/term-mappings/v1.json",
+  "version": "1.0.0",
+  "description": "Reconciliation between id.sifa.* lexicon terms and existing RDF vocabularies. RDF is used here as vocabulary only: Sifa records are Lexicon JSON on the AT Protocol, and nothing here changes how they are stored or transmitted. Match strengths use SKOS mapping relations.",
+  "vocabularies": {
+    "schema": "https://schema.org/",
+    "bibo": "http://purl.org/ontology/bibo/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "org": "http://www.w3.org/ns/org#",
+    "prism": "http://prismstandard.org/namespaces/basic/2.1/",
+    "event": "http://purl.org/NET/c4dm/event.owl#",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "mappings": [
+    {
+      "lexicon": "id.sifa.org.profile",
+      "match": "exactMatch",
+      "terms": ["schema:Organization", "org:FormalOrganization"]
+    },
+    {
+      "lexicon": "id.sifa.profile.certification",
+      "match": "exactMatch",
+      "terms": ["schema:EducationalOccupationalCredential"]
+    },
+    {
+      "lexicon": "id.sifa.profile.certification",
+      "field": "credentialUrl",
+      "match": "exactMatch",
+      "terms": ["schema:url"]
+    },
+    {
+      "lexicon": "id.sifa.profile.certification",
+      "field": "expiresAt",
+      "match": "exactMatch",
+      "terms": ["schema:validUntil"]
+    },
+    {
+      "lexicon": "id.sifa.profile.course",
+      "match": "exactMatch",
+      "terms": ["schema:Course"]
+    },
+    {
+      "lexicon": "id.sifa.profile.course",
+      "field": "number",
+      "match": "exactMatch",
+      "terms": ["schema:courseCode"]
+    },
+    {
+      "lexicon": "id.sifa.profile.education",
+      "match": "closeMatch",
+      "terms": ["schema:EducationalOccupationalCredential"]
+    },
+    {
+      "lexicon": "id.sifa.profile.education",
+      "field": "degree",
+      "match": "closeMatch",
+      "terms": ["schema:hasCredential", "bibo:degree"]
+    },
+    {
+      "lexicon": "id.sifa.profile.education",
+      "field": "fieldOfStudy",
+      "match": "closeMatch",
+      "terms": ["schema:educationalCredentialAwarded"]
+    },
+    {
+      "lexicon": "id.sifa.profile.education",
+      "field": "institution",
+      "match": "exactMatch",
+      "terms": ["schema:alumniOf"]
+    },
+    {
+      "lexicon": "id.sifa.profile.externalAccount",
+      "match": "exactMatch",
+      "terms": ["schema:sameAs", "foaf:account"]
+    },
+    {
+      "lexicon": "id.sifa.profile.honor",
+      "match": "broadMatch",
+      "terms": ["schema:award"]
+    },
+    {
+      "lexicon": "id.sifa.profile.involvement",
+      "match": "broadMatch",
+      "terms": ["org:Membership"]
+    },
+    {
+      "lexicon": "id.sifa.profile.language",
+      "match": "exactMatch",
+      "terms": ["schema:knowsLanguage"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "match": "closeMatch",
+      "terms": ["org:Membership", "schema:OrganizationRole"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "company",
+      "match": "exactMatch",
+      "terms": ["org:organization", "schema:worksFor"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "description",
+      "match": "exactMatch",
+      "terms": ["dcterms:description"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "employmentType",
+      "match": "closeMatch",
+      "terms": ["schema:employmentType"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "endedAt",
+      "match": "exactMatch",
+      "terms": ["schema:endDate"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "entityRef",
+      "match": "closeMatch",
+      "terms": ["schema:sameAs"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "location",
+      "match": "exactMatch",
+      "terms": ["schema:jobLocation"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "startedAt",
+      "match": "exactMatch",
+      "terms": ["schema:startDate"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "title",
+      "match": "exactMatch",
+      "terms": ["org:role", "schema:roleName"]
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "workplaceType",
+      "match": "narrowMatch",
+      "terms": ["schema:jobLocationType"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentation",
+      "match": "closeMatch",
+      "terms": ["bibo:Slideshow", "schema:PresentationDigitalDocument"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentation",
+      "field": "coverImage",
+      "match": "exactMatch",
+      "terms": ["schema:image", "foaf:depiction"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentation",
+      "field": "description",
+      "match": "exactMatch",
+      "terms": ["bibo:abstract", "schema:abstract"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentation",
+      "field": "duration",
+      "match": "narrowMatch",
+      "terms": ["schema:timeRequired"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentation",
+      "field": "intendedAudiences",
+      "match": "closeMatch",
+      "terms": ["schema:audience"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentation",
+      "field": "title",
+      "match": "exactMatch",
+      "terms": ["dcterms:title", "schema:name"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentation",
+      "field": "writeupRef",
+      "match": "closeMatch",
+      "terms": ["dcterms:isReferencedBy", "schema:subjectOf"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "match": "closeMatch",
+      "terms": ["schema:Event", "event:Event"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "address",
+      "match": "exactMatch",
+      "terms": ["schema:location", "event:place"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "coSpeakers",
+      "match": "exactMatch",
+      "terms": ["schema:performer"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "date",
+      "match": "exactMatch",
+      "terms": ["schema:startDate", "event:time"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "eventName",
+      "match": "closeMatch",
+      "terms": ["schema:superEvent", "bibo:Conference"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "mode",
+      "match": "exactMatch",
+      "terms": ["schema:eventAttendanceMode"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "presentationRef",
+      "match": "closeMatch",
+      "terms": ["bibo:presentedAt", "schema:workPerformed"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "role",
+      "match": "closeMatch",
+      "terms": ["bibo:performer", "schema:performer"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "status",
+      "match": "exactMatch",
+      "terms": ["schema:eventStatus"]
+    },
+    {
+      "lexicon": "id.sifa.profile.presentationDelivery",
+      "field": "title",
+      "match": "exactMatch",
+      "terms": ["dcterms:title", "schema:name"]
+    },
+    {
+      "lexicon": "id.sifa.profile.project",
+      "match": "exactMatch",
+      "terms": ["schema:Project", "foaf:Project"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "match": "broadMatch",
+      "terms": ["bibo:Document", "schema:CreativeWork"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "authors",
+      "match": "exactMatch",
+      "terms": ["bibo:authorList", "schema:author"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "description",
+      "match": "exactMatch",
+      "terms": ["bibo:abstract", "schema:abstract"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "publishedAt",
+      "match": "exactMatch",
+      "terms": ["dcterms:issued", "schema:datePublished"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "publisher",
+      "match": "exactMatch",
+      "terms": ["dcterms:publisher", "schema:publisher"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "subtitle",
+      "match": "closeMatch",
+      "terms": ["schema:alternativeHeadline"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "title",
+      "match": "exactMatch",
+      "terms": ["dcterms:title", "schema:name"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "url",
+      "match": "exactMatch",
+      "terms": ["bibo:uri", "schema:url"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "match": "exactMatch",
+      "terms": ["schema:Person", "foaf:Person"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "about",
+      "match": "exactMatch",
+      "terms": ["schema:description"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "avatar",
+      "match": "exactMatch",
+      "terms": ["schema:image", "foaf:depiction"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "displayName",
+      "match": "exactMatch",
+      "terms": ["schema:name", "foaf:name"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "familyName",
+      "match": "exactMatch",
+      "terms": ["schema:familyName", "foaf:family_name"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "givenName",
+      "match": "exactMatch",
+      "terms": ["schema:givenName", "foaf:givenname"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "headline",
+      "match": "closeMatch",
+      "terms": ["schema:jobTitle"]
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "location",
+      "match": "closeMatch",
+      "terms": ["schema:homeLocation"]
+    },
+    {
+      "lexicon": "id.sifa.profile.skill",
+      "match": "closeMatch",
+      "terms": ["schema:knowsAbout", "schema:DefinedTerm"]
+    },
+    {
+      "lexicon": "id.sifa.profile.volunteering",
+      "match": "closeMatch",
+      "terms": ["org:Membership", "schema:OrganizationRole"]
+    }
+  ],
+  "unmapped": [
+    {
+      "lexicon": "id.sifa.confirmation",
+      "reason": "A record affirming another record is reification. schema:Review and schema:ClaimReview both imply an evaluation that a confirmation does not make."
+    },
+    {
+      "lexicon": "id.sifa.endorsement",
+      "reason": "Same reification problem as confirmation. Any mapping that lets a consumer aggregate endorsements into a score works against a descriptive-only trust model."
+    },
+    {
+      "lexicon": "id.sifa.graph.connection",
+      "reason": "foaf:knows carries no consent semantics. A Sifa connection is bilateral and confirmed; flattening it would present an unconfirmed acquaintance claim as mutual."
+    },
+    {
+      "lexicon": "id.sifa.graph.follow",
+      "reason": "See id.sifa.graph.connection."
+    },
+    {
+      "lexicon": "id.sifa.meeting",
+      "reason": "Attestation semantics; same reification problem."
+    }
+  ]
+}


### PR DESCRIPTION
## What

Records which `id.sifa.*` terms mean the same thing as terms already standardised in BIBO, schema.org, DCMI Terms, FOAF and W3C ORG.

Two representations of the same fact:

1. `x-skos:*` keys inline in the lexicon JSON, on the def and on individual properties.
2. `well-known/term-mappings.json`, generated from those annotations by `npm run build:term-mappings`, for consumers that would rather fetch one document than walk 34 schemas.

60 mappings across 16 record types, plus 5 records declared explicitly unmapped.

## Scope, precisely

RDF is used here as **vocabulary only**. Sifa records are Lexicon JSON on the AT Protocol; nothing about how they are stored or transmitted changes. There is no triple store, no SPARQL, no RDF wire format.

An annotation is a one-directional note over a lexicon designed on its own merits. Where a term does not fit, the answer is to say so, not to reshape the lexicon.

## Why annotations are at def and property level, never document level

Tested against `@atproto/lexicon` 0.6.2 and `@atproto/lex-cli` 0.9.9:

| Gate | Result |
|---|---|
| `lexiconDoc.parse()` | passes |
| `Lexicons.add()` across all 43 files | 43 ok, 0 fail |
| Runtime record validation | passes |
| `lex-cli gen-server` | exit 0, generated **types byte-identical** |
| Full test suite | 448 passing |

One asymmetry decided the placement: a **document-level** key survives `lex-cli` codegen but is **silently stripped** by `lexiconDoc.parse`, so it would be present in some representations and absent in others with no error either way. Def and property level survive both. A test enforces that nothing lands at document level.

## PDS side

`com.atproto.lexicon.schema` declares exactly one property:

```json
{ "type": "object", "required": ["lexicon"], "properties": { "lexicon": { "type": "integer" } } }
```

Everything else is unvalidated passthrough, and atproto object validation accepts unknown properties by design. A live round-trip against the authority PDS came back byte-equal to the repo file apart from an added `$type`, so records are stored verbatim. `publish-lexicons.ts` reads each file with a bare `JSON.parse` and hands it straight to `putRecord`, so annotations reach the PDS unaltered.

## What is deliberately not mapped

`confirmation`, `endorsement`, `graph.connection`, `graph.follow` and `meeting`, each with a stated reason in the generated document. These are load bearing: an approximate mapping would let a consumer draw a conclusion the record does not support. `foaf:knows` in particular carries no consent semantics, and a test asserts it appears nowhere.

## Tests

57 new. Annotation well-formedness, known vocabulary prefixes, no document-level keys, generated-document sync with the lexicons, coverage of every record type Sifa emits structured data for, the `foaf:knows` prohibition, and that nothing is both mapped and declared unmapped.

## Follow-ups

- `@singi-labs/sifa-sdk` carries the same table as `TERM_MAPPINGS` for its emitters. Two representations, no automated check between them. Worth collapsing; filing separately rather than widening this PR.
- Serving `well-known/term-mappings.json` at `https://sifa.id/.well-known/sifa-term-mappings.json` is a sifa-api change, next.
- Related: #85. That bug means this merge republishes every lexicon rather than the 16 that changed.