### PR TITLE
feat(lexicons): make the term mapping document complete

### DIFF
--- a/lexicons/id/sifa/org/profile.json
+++ b/lexicons/id/sifa/org/profile.json
@@ -65,7 +65,8 @@
           }
         }
       },
-      "x-skos:exactMatch": ["schema:Organization", "org:FormalOrganization"]
+      "x-skos:exactMatch": ["schema:Organization", "org:FormalOrganization"],
+      "x-skos:note": "ROR is the value anchor."
     }
   }
 }

--- a/lexicons/id/sifa/profile/education.json
+++ b/lexicons/id/sifa/profile/education.json
@@ -41,7 +41,8 @@
             "maxGraphemes": 256,
             "maxLength": 2560,
             "description": "Field of study or major.",
-            "x-skos:closeMatch": ["schema:educationalCredentialAwarded"]
+            "x-skos:closeMatch": ["schema:educationalCredentialAwarded"],
+            "x-skos:note": "ISCED-F is the value anchor."
           },
           "grade": {
             "type": "string",
@@ -86,7 +87,8 @@
           }
         }
       },
-      "x-skos:closeMatch": ["schema:EducationalOccupationalCredential"]
+      "x-skos:closeMatch": ["schema:EducationalOccupationalCredential"],
+      "x-skos:note": "One record maps to two schema.org assertions: alumniOf for the institution and hasCredential for the degree."
     }
   }
 }

--- a/lexicons/id/sifa/profile/honor.json
+++ b/lexicons/id/sifa/profile/honor.json
@@ -51,7 +51,8 @@
           }
         }
       },
-      "x-skos:broadMatch": ["schema:award"]
+      "x-skos:broadMatch": ["schema:award"],
+      "x-skos:note": "schema:award is a bare string, so issuer and date are lost. No better term exists in BIBO either."
     }
   }
 }

--- a/lexicons/id/sifa/profile/involvement.json
+++ b/lexicons/id/sifa/profile/involvement.json
@@ -112,7 +112,8 @@
           }
         }
       },
-      "x-skos:broadMatch": ["org:Membership"]
+      "x-skos:broadMatch": ["org:Membership"],
+      "x-skos:note": "The kind known values have no external equivalent."
     }
   }
 }

--- a/lexicons/id/sifa/profile/position.json
+++ b/lexicons/id/sifa/profile/position.json
@@ -66,7 +66,8 @@
               "id.sifa.defs#boardObserver",
               "id.sifa.defs#advisor"
             ],
-            "x-skos:closeMatch": ["schema:employmentType"]
+            "x-skos:closeMatch": ["schema:employmentType"],
+            "x-skos:note": "schema:employmentType is free text. ESCO is the better value anchor."
           },
           "onBehalfOf": {
             "type": "string",
@@ -88,7 +89,8 @@
             "type": "string",
             "description": "Workplace arrangement (on-site, remote, hybrid).",
             "knownValues": ["id.sifa.defs#onSite", "id.sifa.defs#remote", "id.sifa.defs#hybrid"],
-            "x-skos:narrowMatch": ["schema:jobLocationType"]
+            "x-skos:narrowMatch": ["schema:jobLocationType"],
+            "x-skos:note": "schema.org models only a remote flag; Sifa distinguishes onSite, remote, and hybrid."
           },
           "location": {
             "type": "ref",

--- a/lexicons/id/sifa/profile/presentation.json
+++ b/lexicons/id/sifa/profile/presentation.json
@@ -30,7 +30,8 @@
             "type": "ref",
             "ref": "#duration",
             "description": "Typical length of the presentation, a fixed value or a range, in minutes.",
-            "x-skos:narrowMatch": ["schema:timeRequired"]
+            "x-skos:narrowMatch": ["schema:timeRequired"],
+            "x-skos:note": "The lexicon models a range; schema:timeRequired is a single ISO 8601 duration."
           },
           "intendedAudiences": {
             "type": "array",
@@ -72,7 +73,8 @@
           }
         }
       },
-      "x-skos:closeMatch": ["bibo:Slideshow", "schema:PresentationDigitalDocument"]
+      "x-skos:closeMatch": ["bibo:Slideshow", "schema:PresentationDigitalDocument"],
+      "x-skos:note": "Neither term carries the \"reusable, deliverable more than once\" semantics of the Sifa record."
     },
     "duration": {
       "type": "object",

--- a/lexicons/id/sifa/profile/presentationDelivery.json
+++ b/lexicons/id/sifa/profile/presentationDelivery.json
@@ -41,7 +41,8 @@
               "id.sifa.defs#workshop",
               "id.sifa.defs#host"
             ],
-            "x-skos:closeMatch": ["bibo:performer", "schema:performer"]
+            "x-skos:closeMatch": ["bibo:performer", "schema:performer"],
+            "x-skos:note": "No external vocabulary distinguishes presenter, panelist, keynote, workshop and host at this granularity."
           },
           "eventName": {
             "type": "string",
@@ -76,7 +77,8 @@
               "community.lexicon.calendar.event#virtual",
               "community.lexicon.calendar.event#hybrid"
             ],
-            "x-skos:exactMatch": ["schema:eventAttendanceMode"]
+            "x-skos:exactMatch": ["schema:eventAttendanceMode"],
+            "x-skos:note": "The community.lexicon.calendar.event known values are already one-to-one with the schema.org enumeration."
           },
           "status": {
             "type": "string",
@@ -88,7 +90,8 @@
               "community.lexicon.calendar.event#rescheduled",
               "community.lexicon.calendar.event#planned"
             ],
-            "x-skos:exactMatch": ["schema:eventStatus"]
+            "x-skos:exactMatch": ["schema:eventStatus"],
+            "x-skos:note": "As with mode, already one-to-one with the schema.org enumeration."
           },
           "links": {
             "type": "array",
@@ -121,7 +124,8 @@
           }
         }
       },
-      "x-skos:closeMatch": ["schema:Event", "event:Event"]
+      "x-skos:closeMatch": ["schema:Event", "event:Event"],
+      "x-skos:note": "BIBO models this relation as bibo:Slideshow bibo:presentedAt event:Event."
     }
   }
 }

--- a/lexicons/id/sifa/profile/publication.json
+++ b/lexicons/id/sifa/profile/publication.json
@@ -59,7 +59,8 @@
               "ref": "#author"
             },
             "description": "Co-authors. The record owner is always an implicit author.",
-            "x-skos:exactMatch": ["bibo:authorList", "schema:author"]
+            "x-skos:exactMatch": ["bibo:authorList", "schema:author"],
+            "x-skos:note": "bibo:authorList is an ordered rdf:List and preserves author order, which schema:author does not guarantee."
           },
           "publishedAt": {
             "type": "string",
@@ -73,7 +74,8 @@
           }
         }
       },
-      "x-skos:broadMatch": ["bibo:Document", "schema:CreativeWork"]
+      "x-skos:broadMatch": ["bibo:Document", "schema:CreativeWork"],
+      "x-skos:note": "Refine to bibo:AcademicArticle, bibo:Book, bibo:Report or bibo:Thesis when a resource type is known. COAR is the value anchor."
     },
     "author": {
       "type": "object",

--- a/lexicons/id/sifa/profile/skill.json
+++ b/lexicons/id/sifa/profile/skill.json
@@ -43,7 +43,8 @@
           }
         }
       },
-      "x-skos:closeMatch": ["schema:knowsAbout", "schema:DefinedTerm"]
+      "x-skos:closeMatch": ["schema:knowsAbout", "schema:DefinedTerm"],
+      "x-skos:note": "ESCO is the value anchor."
     }
   }
 }

--- a/scripts/build-term-mappings.js
+++ b/scripts/build-term-mappings.js
@@ -34,12 +34,43 @@ export const MATCH_KEYS = [
 ];
 
 /**
- * Records deliberately left unmapped, with the reason. Stated explicitly so a
- * consumer can tell "we have not got to it" apart from "no external term is
- * appropriate here". These carry no annotation in the lexicon itself, because
- * the absence is the point.
+ * Terms Sifa deliberately does not map, with the reason.
+ *
+ * Stated rather than omitted so a consumer can tell "not got to it yet" apart
+ * from "no external term is appropriate here". Record-level entries mean the
+ * whole record has no external equivalent; field-level entries sit inside a
+ * record that is otherwise mapped.
+ *
+ * These carry no annotation in the lexicon itself, because the absence is the
+ * point.
  */
 export const UNMAPPED = [
+  {
+    lexicon: 'id.sifa.profile.self',
+    field: 'pronouns',
+    reason: 'No stable external term. schema.org has no pronouns property.',
+  },
+  {
+    lexicon: 'id.sifa.profile.self',
+    field: 'discoverable',
+    reason: 'Sifa indexing control, not a fact about the person.',
+  },
+  {
+    lexicon: 'id.sifa.profile.position',
+    field: 'isPrimary',
+    reason: 'Sifa display ordering concern.',
+  },
+  {
+    lexicon: 'id.sifa.profile.education',
+    field: 'grade',
+    reason: 'No comparable external term; grading scales are not portable.',
+  },
+  {
+    lexicon: 'id.sifa.profile.language',
+    field: 'proficiency',
+    reason:
+      'The known values are CEFR-shaped but not CEFR-named. Map only; renaming a published lexicon for a cosmetic gain is not worth the break.',
+  },
   {
     lexicon: 'id.sifa.confirmation',
     reason:
@@ -48,15 +79,38 @@ export const UNMAPPED = [
   {
     lexicon: 'id.sifa.endorsement',
     reason:
-      'Same reification problem as confirmation. Any mapping that lets a consumer aggregate endorsements into a score works against a descriptive-only trust model.',
+      'Same reification problem as confirmation. Any mapping that lets a consumer aggregate endorsements into a score works against the descriptive-only trust model.',
   },
   {
     lexicon: 'id.sifa.graph.connection',
     reason:
-      'foaf:knows carries no consent semantics. A Sifa connection is bilateral and confirmed; flattening it would present an unconfirmed acquaintance claim as mutual.',
+      'foaf:knows carries no consent semantics. A Sifa connection is bilateral and confirmed; flattening it to foaf:knows would misrepresent an unconfirmed acquaintance claim as mutual.',
   },
-  { lexicon: 'id.sifa.graph.follow', reason: 'See id.sifa.graph.connection.' },
-  { lexicon: 'id.sifa.meeting', reason: 'Attestation semantics; same reification problem.' },
+  {
+    lexicon: 'id.sifa.graph.follow',
+    reason: 'See id.sifa.graph.connection.',
+  },
+  {
+    lexicon: 'id.sifa.meeting',
+    reason: 'Attestation semantics; same reification problem as confirmation.',
+  },
+];
+
+/**
+ * Mappings for fields that exist on the AppView view type but not on the
+ * lexicon, so they cannot be expressed as an inline annotation.
+ *
+ * Keep this list as short as possible. Each entry is a place where the
+ * published schema and what Sifa actually serves have diverged.
+ */
+export const VIEW_ONLY_MAPPINGS = [
+  {
+    lexicon: 'id.sifa.profile.publication',
+    field: 'doi',
+    terms: ['bibo:doi', 'prism:doi'],
+    match: 'exactMatch',
+    note: 'Present on the AppView view type (ORCID-sourced), not yet on the id.sifa.profile.publication lexicon, so user-authored publications cannot carry one.',
+  },
 ];
 
 export function findJsonFiles(dir) {
@@ -71,7 +125,11 @@ export function findJsonFiles(dir) {
 
 function matchOf(node) {
   for (const key of MATCH_KEYS) {
-    if (Array.isArray(node?.[key])) return { match: key.slice('x-skos:'.length), terms: node[key] };
+    if (Array.isArray(node?.[key])) {
+      const found = { match: key.slice('x-skos:'.length), terms: node[key] };
+      if (typeof node['x-skos:note'] === 'string') found.note = node['x-skos:note'];
+      return found;
+    }
   }
   return null;
 }
@@ -108,7 +166,7 @@ export function buildDocument() {
     description:
       'Reconciliation between id.sifa.* lexicon terms and existing RDF vocabularies. RDF is used here as vocabulary only: Sifa records are Lexicon JSON on the AT Protocol, and nothing here changes how they are stored or transmitted. Match strengths use SKOS mapping relations.',
     vocabularies: VOCABULARIES,
-    mappings: collectMappings(),
+    mappings: [...collectMappings(), ...VIEW_ONLY_MAPPINGS],
     unmapped: UNMAPPED,
   };
 }

--- a/tests/term-mappings.test.ts
+++ b/tests/term-mappings.test.ts
@@ -26,12 +26,17 @@ function isAnnotationKey(key: string) {
 }
 
 describe('term annotations are well formed', () => {
-  it('every x-skos key is a known SKOS mapping relation', () => {
+  it('every x-skos key is a known SKOS mapping relation or a note', () => {
     for (const { file, doc } of docs) {
       const walk = (node: unknown, path: string) => {
         if (!node || typeof node !== 'object') return;
         for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
-          if (isAnnotationKey(key)) {
+          if (key === 'x-skos:note') {
+            // Free-text rationale riding alongside a mapping, not a mapping
+            // relation itself.
+            expect(typeof value, `${file} ${path}.${key}`).toBe('string');
+            expect((value as string).length, `${file} ${path}.${key} is empty`).toBeGreaterThan(0);
+          } else if (isAnnotationKey(key)) {
             expect(MATCH_KEYS, `${file} ${path}.${key}`).toContain(key);
             expect(Array.isArray(value), `${file} ${path}.${key} must be an array`).toBe(true);
             expect((value as unknown[]).length, `${file} ${path}.${key} is empty`).toBeGreaterThan(
@@ -109,10 +114,23 @@ describe('generated well-known document', () => {
     }
   });
 
-  it('does not annotate a record it declares unmapped', () => {
-    const mapped = new Set(generated.mappings.map((m) => m.lexicon));
+  it('never both maps and unmaps the same thing', () => {
+    // Disjoint per lexicon+field, not per lexicon: a record can be mapped
+    // while one of its fields deliberately is not (id.sifa.profile.self maps
+    // to schema:Person, but `pronouns` has no external equivalent).
+    const key = (m) => `${m.lexicon}#${m.field ?? ''}`;
+    const mapped = new Set(generated.mappings.map(key));
     for (const entry of UNMAPPED) {
-      expect(mapped, `${entry.lexicon} is both mapped and declared unmapped`).not.toContain(
+      expect(mapped, `${key(entry)} is both mapped and declared unmapped`).not.toContain(
+        key(entry),
+      );
+    }
+  });
+
+  it('does not annotate a record it declares unmapped at record level', () => {
+    const mappedLexicons = new Set(generated.mappings.map((m) => m.lexicon));
+    for (const entry of UNMAPPED.filter((u) => !u.field)) {
+      expect(mappedLexicons, `${entry.lexicon} is unmapped at record level`).not.toContain(
         entry.lexicon,
       );
     }

--- a/well-known/term-mappings.json
+++ b/well-known/term-mappings.json
@@ -16,7 +16,8 @@
     {
       "lexicon": "id.sifa.org.profile",
       "match": "exactMatch",
-      "terms": ["schema:Organization", "org:FormalOrganization"]
+      "terms": ["schema:Organization", "org:FormalOrganization"],
+      "note": "ROR is the value anchor."
     },
     {
       "lexicon": "id.sifa.profile.certification",
@@ -49,7 +50,8 @@
     {
       "lexicon": "id.sifa.profile.education",
       "match": "closeMatch",
-      "terms": ["schema:EducationalOccupationalCredential"]
+      "terms": ["schema:EducationalOccupationalCredential"],
+      "note": "One record maps to two schema.org assertions: alumniOf for the institution and hasCredential for the degree."
     },
     {
       "lexicon": "id.sifa.profile.education",
@@ -61,7 +63,8 @@
       "lexicon": "id.sifa.profile.education",
       "field": "fieldOfStudy",
       "match": "closeMatch",
-      "terms": ["schema:educationalCredentialAwarded"]
+      "terms": ["schema:educationalCredentialAwarded"],
+      "note": "ISCED-F is the value anchor."
     },
     {
       "lexicon": "id.sifa.profile.education",
@@ -77,12 +80,14 @@
     {
       "lexicon": "id.sifa.profile.honor",
       "match": "broadMatch",
-      "terms": ["schema:award"]
+      "terms": ["schema:award"],
+      "note": "schema:award is a bare string, so issuer and date are lost. No better term exists in BIBO either."
     },
     {
       "lexicon": "id.sifa.profile.involvement",
       "match": "broadMatch",
-      "terms": ["org:Membership"]
+      "terms": ["org:Membership"],
+      "note": "The kind known values have no external equivalent."
     },
     {
       "lexicon": "id.sifa.profile.language",
@@ -110,7 +115,8 @@
       "lexicon": "id.sifa.profile.position",
       "field": "employmentType",
       "match": "closeMatch",
-      "terms": ["schema:employmentType"]
+      "terms": ["schema:employmentType"],
+      "note": "schema:employmentType is free text. ESCO is the better value anchor."
     },
     {
       "lexicon": "id.sifa.profile.position",
@@ -146,12 +152,14 @@
       "lexicon": "id.sifa.profile.position",
       "field": "workplaceType",
       "match": "narrowMatch",
-      "terms": ["schema:jobLocationType"]
+      "terms": ["schema:jobLocationType"],
+      "note": "schema.org models only a remote flag; Sifa distinguishes onSite, remote, and hybrid."
     },
     {
       "lexicon": "id.sifa.profile.presentation",
       "match": "closeMatch",
-      "terms": ["bibo:Slideshow", "schema:PresentationDigitalDocument"]
+      "terms": ["bibo:Slideshow", "schema:PresentationDigitalDocument"],
+      "note": "Neither term carries the \"reusable, deliverable more than once\" semantics of the Sifa record."
     },
     {
       "lexicon": "id.sifa.profile.presentation",
@@ -169,7 +177,8 @@
       "lexicon": "id.sifa.profile.presentation",
       "field": "duration",
       "match": "narrowMatch",
-      "terms": ["schema:timeRequired"]
+      "terms": ["schema:timeRequired"],
+      "note": "The lexicon models a range; schema:timeRequired is a single ISO 8601 duration."
     },
     {
       "lexicon": "id.sifa.profile.presentation",
@@ -192,7 +201,8 @@
     {
       "lexicon": "id.sifa.profile.presentationDelivery",
       "match": "closeMatch",
-      "terms": ["schema:Event", "event:Event"]
+      "terms": ["schema:Event", "event:Event"],
+      "note": "BIBO models this relation as bibo:Slideshow bibo:presentedAt event:Event."
     },
     {
       "lexicon": "id.sifa.profile.presentationDelivery",
@@ -222,7 +232,8 @@
       "lexicon": "id.sifa.profile.presentationDelivery",
       "field": "mode",
       "match": "exactMatch",
-      "terms": ["schema:eventAttendanceMode"]
+      "terms": ["schema:eventAttendanceMode"],
+      "note": "The community.lexicon.calendar.event known values are already one-to-one with the schema.org enumeration."
     },
     {
       "lexicon": "id.sifa.profile.presentationDelivery",
@@ -234,13 +245,15 @@
       "lexicon": "id.sifa.profile.presentationDelivery",
       "field": "role",
       "match": "closeMatch",
-      "terms": ["bibo:performer", "schema:performer"]
+      "terms": ["bibo:performer", "schema:performer"],
+      "note": "No external vocabulary distinguishes presenter, panelist, keynote, workshop and host at this granularity."
     },
     {
       "lexicon": "id.sifa.profile.presentationDelivery",
       "field": "status",
       "match": "exactMatch",
-      "terms": ["schema:eventStatus"]
+      "terms": ["schema:eventStatus"],
+      "note": "As with mode, already one-to-one with the schema.org enumeration."
     },
     {
       "lexicon": "id.sifa.profile.presentationDelivery",
@@ -256,13 +269,15 @@
     {
       "lexicon": "id.sifa.profile.publication",
       "match": "broadMatch",
-      "terms": ["bibo:Document", "schema:CreativeWork"]
+      "terms": ["bibo:Document", "schema:CreativeWork"],
+      "note": "Refine to bibo:AcademicArticle, bibo:Book, bibo:Report or bibo:Thesis when a resource type is known. COAR is the value anchor."
     },
     {
       "lexicon": "id.sifa.profile.publication",
       "field": "authors",
       "match": "exactMatch",
-      "terms": ["bibo:authorList", "schema:author"]
+      "terms": ["bibo:authorList", "schema:author"],
+      "note": "bibo:authorList is an ordered rdf:List and preserves author order, which schema:author does not guarantee."
     },
     {
       "lexicon": "id.sifa.profile.publication",
@@ -350,26 +365,59 @@
     {
       "lexicon": "id.sifa.profile.skill",
       "match": "closeMatch",
-      "terms": ["schema:knowsAbout", "schema:DefinedTerm"]
+      "terms": ["schema:knowsAbout", "schema:DefinedTerm"],
+      "note": "ESCO is the value anchor."
     },
     {
       "lexicon": "id.sifa.profile.volunteering",
       "match": "closeMatch",
       "terms": ["org:Membership", "schema:OrganizationRole"]
+    },
+    {
+      "lexicon": "id.sifa.profile.publication",
+      "field": "doi",
+      "terms": ["bibo:doi", "prism:doi"],
+      "match": "exactMatch",
+      "note": "Present on the AppView view type (ORCID-sourced), not yet on the id.sifa.profile.publication lexicon, so user-authored publications cannot carry one."
     }
   ],
   "unmapped": [
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "pronouns",
+      "reason": "No stable external term. schema.org has no pronouns property."
+    },
+    {
+      "lexicon": "id.sifa.profile.self",
+      "field": "discoverable",
+      "reason": "Sifa indexing control, not a fact about the person."
+    },
+    {
+      "lexicon": "id.sifa.profile.position",
+      "field": "isPrimary",
+      "reason": "Sifa display ordering concern."
+    },
+    {
+      "lexicon": "id.sifa.profile.education",
+      "field": "grade",
+      "reason": "No comparable external term; grading scales are not portable."
+    },
+    {
+      "lexicon": "id.sifa.profile.language",
+      "field": "proficiency",
+      "reason": "The known values are CEFR-shaped but not CEFR-named. Map only; renaming a published lexicon for a cosmetic gain is not worth the break."
+    },
     {
       "lexicon": "id.sifa.confirmation",
       "reason": "A record affirming another record is reification. schema:Review and schema:ClaimReview both imply an evaluation that a confirmation does not make."
     },
     {
       "lexicon": "id.sifa.endorsement",
-      "reason": "Same reification problem as confirmation. Any mapping that lets a consumer aggregate endorsements into a score works against a descriptive-only trust model."
+      "reason": "Same reification problem as confirmation. Any mapping that lets a consumer aggregate endorsements into a score works against the descriptive-only trust model."
     },
     {
       "lexicon": "id.sifa.graph.connection",
-      "reason": "foaf:knows carries no consent semantics. A Sifa connection is bilateral and confirmed; flattening it would present an unconfirmed acquaintance claim as mutual."
+      "reason": "foaf:knows carries no consent semantics. A Sifa connection is bilateral and confirmed; flattening it to foaf:knows would misrepresent an unconfirmed acquaintance claim as mutual."
     },
     {
       "lexicon": "id.sifa.graph.follow",
@@ -377,7 +425,7 @@
     },
     {
       "lexicon": "id.sifa.meeting",
-      "reason": "Attestation semantics; same reification problem."
+      "reason": "Attestation semantics; same reification problem as confirmation."
     }
   ]
 }


### PR DESCRIPTION
## What

Makes `well-known/term-mappings.json` a complete statement of Sifa's term reconciliation, so sifa-sdk can derive from it instead of keeping a second hand-written copy.

Pairs with singi-labs/sifa-sdk#453, which switches `TERM_MAPPINGS` to a synced copy of this document.

## Why

The same facts were maintained in two repos with nothing checking they agreed:

| | Here (before) | sifa-sdk `TERM_MAPPINGS` |
|---|---|---|
| Mappings | 60 | 61 |
| Unmapped | 5, record-level only | 10, record and field level |
| Notes | none | 17 |

Two hand-maintained copies of the same thing is one too many, and the smaller one was the one published to the PDS.

## What changed

- **`x-skos:note`** alongside the annotations, carrying the rationale that previously only existed in the SDK ("schema:employmentType is free text, ESCO is the better value anchor", and so on).
- **The unmapped list now covers field-level cases**: `self.pronouns`, `self.discoverable`, `position.isPrimary`, `education.grade`, `language.proficiency`. Previously only whole records could be declared unmapped, which meant a mapped record could not say "this one field has no external equivalent".
- **`VIEW_ONLY_MAPPINGS`**, currently one entry: `publication.doi`. The DOI exists on the AppView view type (ORCID-sourced) but not on the lexicon, so it cannot be an inline annotation. Kept deliberately short and commented as such, because each entry is a place where the published schema and what Sifa serves have diverged.

The document now reproduces `TERM_MAPPINGS` exactly, 61 mappings and 10 unmapped, verified entry by entry including notes.

## Tests

Two existing assertions of mine were wrong and are corrected:

- *"every x-skos key is a known SKOS mapping relation"* did not know about `x-skos:note`, which is free text rather than a relation.
- *"does not annotate a record it declares unmapped"* compared whole lexicons. Disjointness is per lexicon **and field**: `profile.self` maps to `schema:Person` while its `pronouns` field is deliberately unmapped. Split into a per-field check plus a record-level one.

449 passing, typecheck, codegen and format clean.